### PR TITLE
Prepare release for Rust 1.2.5

### DIFF
--- a/.github/workflows/rust-linux.yml
+++ b/.github/workflows/rust-linux.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Install build dependencies
-        run: dnf -y install binutils ca-certificates curl file gcc git gzip tar xz
+        run: dnf -y install binutils ca-certificates curl file gcc git gzip tar xz zip
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
           file target/release/dsmon
           objdump -T target/release/dsmon | grep -o 'GLIBC_[0-9.]*' | sort -Vu | tail -1 || true
 
-      - name: Create tarball
+      - name: Create release packages
         working-directory: rust-linux
         run: |
           if [[ "${GITHUB_REF_NAME}" == rust-v* ]]; then
@@ -73,6 +73,8 @@ jobs:
           cp package/install.sh package/uninstall.sh package/dsmon.service "target/package/${package}/"
           cp -R plasmoid/package "target/package/${package}/plasmoid"
           tar -czf "target/package/${package}.tar.gz" -C target/package "${package}"
+          plasmoid="deepseek-balance-monitor-${version}-plasmoid.plasmoid"
+          (cd plasmoid/package && zip -qr "../../target/package/${plasmoid}" .)
 
       - name: Generate SHA256 checksum
         working-directory: rust-linux
@@ -82,10 +84,10 @@ jobs:
           echo "Generated checksums:"
           cat checksums.txt
 
-      - name: Upload tarball
+      - name: Upload Linux packages
         uses: actions/upload-artifact@v4
         with:
-          name: deepseek-balance-monitor-linux-x86_64
+          name: deepseek-balance-monitor-linux
           path: rust-linux/target/package/*.tar.gz
 
       - name: Prepare release metadata
@@ -100,6 +102,7 @@ jobs:
           name: ${{ steps.release_metadata.outputs.release_name }}
           files: |
             rust-linux/target/package/*.tar.gz
+            rust-linux/target/package/*.plasmoid
             rust-linux/target/package/checksums.txt
           body: |
             ## Rust builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to DeepSeek Balance Monitor are documented here.
 
+## Rust v1.2.5 (2026-05-12)
+
+### Added
+
+- Standalone Plasma widget release asset: `deepseek-balance-monitor-*-plasmoid.plasmoid`
+- Linux release tarballs now include the same Plasma widget package under `plasmoid/`
+- Linux release assets include `checksums.txt` for tarball verification
+
+### Changed
+
+- Plasma widget display now follows the Rainmeter layout: balance line, relative last-check time, API service status, and estimated remaining time
+- Plasma widget language settings now sync `cfg_language` back to `ui_language`, so English/Chinese selection survives Plasma restarts
+- Low-balance display colour now takes priority over API-degraded colour, matching Rainmeter accent rules
+- Rust Linux and Rust Windows service-status checks now use the FlashDuty-backed DeepSeek status page
+- Consumption estimates use topped-balance history over a 7-day window, with retention-period fallback when needed
+- Proxy settings now include an explicit enable toggle while preserving the proxy address when disabled
+
+### Fixed
+
+- Fixed Linux Plasma language changes appearing to reset after restarting `plasmashell`
+- Fixed removed DeepSeek status REST API usage in Rust ports
+- Fixed Windows settings title/footer behaviour to match the v1.2 settings design
+
 ## Python v1.2.2 (2026-05-12)
 
 ### Fixed

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -2,6 +2,29 @@
 
 所有值得记录的变更均记录于此。
 
+## Rust v1.2.5 (2026-05-12)
+
+### 新增
+
+- 独立 Plasma 小组件发布资产：`deepseek-balance-monitor-*-plasmoid.plasmoid`
+- Linux 发布 tar 包现在也在 `plasmoid/` 目录内包含同一套 Plasma 小组件
+- Linux 发布资产新增 `checksums.txt`，用于校验 tar 包完整性
+
+### 变更
+
+- Plasma 小组件显示同步 Rainmeter 布局：余额行、相对上次查询时间、API 服务状态和预计剩余时间
+- Plasma 小组件语言设置现在会把 `cfg_language` 同步回 `ui_language`，中英文选择在重启 Plasma 后仍保持
+- 低余额显示颜色优先于 API 服务异常颜色，与 Rainmeter 点缀色规则保持一致
+- Rust Linux 和 Rust Windows 的服务状态查询改用 FlashDuty 后台的 DeepSeek 状态页
+- 消耗估算改用 7 天 topped 余额历史，数据不足时 fallback 到保留期窗口
+- 代理设置新增显式启用开关，关闭代理时保留代理地址不清除
+
+### 修复
+
+- 修复 Linux Plasma 修改语言后重启 `plasmashell` 又恢复中文的问题
+- 修复 Rust 移植版仍调用已移除 DeepSeek 状态 REST API 的问题
+- 修复 Windows 设置页标题和底部状态行，使其符合 v1.2 设置页设计
+
 ## Python v1.2.2 (2026-05-12)
 
 ### 修复

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A Windows tray app and Linux CLI/Plasma widget that periodically query the DeepS
 
 ## Current Version Highlights
 
+- Rust 1.2.5 refreshes the Linux Plasma widget display model: balance, relative last check, API service status, and estimated availability now match the Rainmeter widget layout.
+- Plasma widget language changes now persist across Plasma restarts by syncing the widget `cfg_language` setting back to `dsmon`'s `ui_language`.
+- Linux releases now include both the full `.tar.gz` package and a standalone `.plasmoid` widget package for direct download.
+- Rust Windows and Rust Linux now read DeepSeek service status from the FlashDuty-backed status page after the old `status.deepseek.com/api/v2` API stopped working.
 - Custom icon styling with 5 preset colour themes, custom hex colours, and an icon stroke toggle.
 - History viewer with paginated balance records, an interactive trend chart, and consumption rate analysis.
 - CSV export with a configurable save path.
@@ -28,6 +32,7 @@ Rust Linux-specific:
 
 - Rust Linux: `dsmon set-key` and `dsmon set <field> <value>`; daemon reloads config on each poll cycle; CLI stays English-only.
 - Plasma 6 widget: transparent liquid-glass view with balance, last check, service status, estimated availability, refresh control, and emoji status text.
+- Plasma 6 widget display is intentionally compact: the main desktop widget shows the balance line, relative last-check time, DeepSeek API status, and estimated remaining time.
 
 ## Features
 
@@ -60,7 +65,27 @@ Rust Linux-specific:
 
 ### Direct Download
 
-Grab the latest files from [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases). Use `DeepSeekBalanceMonitor.exe` for the Python-packaged build, `deepseek-balance-monitor.exe` for the Rust Windows build, or `deepseek-balance-monitor-*-linux-x86_64.tar.gz` for Linux. Release builds do not require Python.
+Grab the latest files from [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases). Use `DeepSeekBalanceMonitor.exe` for the Python-packaged build, `deepseek-balance-monitor-*-windows-*.exe` for the Rust Windows build, `deepseek-balance-monitor-*-linux-x86_64.tar.gz` for the full Linux package, or `deepseek-balance-monitor-*-plasmoid.plasmoid` for the standalone Plasma widget. Release builds do not require Python.
+
+### Optional Plasma Widget (Linux)
+
+The Plasma widget is optional and requires KDE Plasma 6. It reads local status from `dsmon` and never receives your API key directly.
+
+1. Download `deepseek-balance-monitor-*-linux-x86_64.tar.gz` from [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases).
+2. Extract the archive and run the installer:
+
+   ```bash
+   tar -xzf deepseek-balance-monitor-*-linux-x86_64.tar.gz
+   cd deepseek-balance-monitor-*-linux-x86_64
+   sudo ./install.sh
+   systemctl --user enable --now dsmon.service
+   ```
+
+3. Add **DeepSeek Balance Monitor** from Plasma's widget picker.
+4. Open the widget settings, enter your DeepSeek API key or use `dsmon set-key`, then click **Save**.
+5. Use **Check** in the widget to refresh the balance manually.
+
+For widget-only installs, download `deepseek-balance-monitor-*-plasmoid.plasmoid` and install it with Plasma's widget installer. The full Linux tarball also contains the same widget under its `plasmoid/` directory.
 
 ### Optional Rainmeter Widget (Windows)
 
@@ -68,7 +93,7 @@ The Rainmeter desktop widget is optional. It reads local status from a running D
 
 1. Install Rainmeter from [rainmeter.net](https://www.rainmeter.net/).
 2. Run any Windows build (Python or Rust) — the local status interface starts automatically.
-3. Download `deepseek-balance-monitor-*-rainmeter.rmskin` from [Releases](https://github.com/SrtaEstrella/DeepSeekBalanceMonitor/releases).
+3. Download `deepseek-balance-monitor-*-rainmeter.rmskin` from [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases).
 4. Double-click the `.rmskin` file and install the skin.
 5. In Rainmeter, load `DeepSeekBalanceMonitor\DeepSeekBalanceMonitor.ini` (or `DeepSeekBalanceMonitor.en.ini` for English).
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,6 +14,10 @@
 
 ## 当前版本亮点
 
+- Rust 1.2.5 刷新 Linux Plasma 小组件显示模型：余额、相对上次查询、API 服务状态和预计可用时间现在与 Rainmeter 小工具布局一致。
+- Plasma 小组件语言修改现在会同步 `cfg_language` 到 `dsmon` 的 `ui_language`，重启 Plasma 后仍能保持中英文选择。
+- Linux 发布现在同时提供完整 `.tar.gz` 包和可直接下载的独立 `.plasmoid` 小组件包。
+- Rust Windows 和 Rust Linux 已改用 FlashDuty 后台的 DeepSeek 状态页，替代失效的 `status.deepseek.com/api/v2` 旧接口。
 - 自定义图标样式：5 套预置配色、自定义 hex 颜色和图标描边开关。
 - 历史记录页：分页余额记录、交互式趋势图和消耗速率分析。
 - CSV 导出支持配置保存路径。
@@ -27,6 +31,7 @@
 Rust Linux 版本限定：
 - Rust Linux：`dsmon set-key` 和 `dsmon set <field> <value>`；daemon 每轮轮询重新读取配置；CLI 固定英文输出。
 - Plasma 6 小组件：透明液态玻璃桌面样式，余额、上次查询、服务状态、预计可用时间、刷新按钮和 emoji 状态。
+- Plasma 6 小组件显示刻意保持紧凑：桌面主视图显示余额行、相对上次查询时间、DeepSeek API 状态和预计剩余时间。
 
 
 ## 功能
@@ -60,7 +65,27 @@ Rust Linux 版本限定：
 
 ### 直接下载
 
-从 [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases) 下载最新文件。Python 打包版使用 `DeepSeekBalanceMonitor.exe`，Rust Windows 版使用 `deepseek-balance-monitor.exe`，Linux 版使用 `deepseek-balance-monitor-*-linux-x86_64.tar.gz`。发布版无需 Python 环境。
+从 [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases) 下载最新文件。Python 打包版使用 `DeepSeekBalanceMonitor.exe`，Rust Windows 版使用 `deepseek-balance-monitor-*-windows-*.exe`，Linux 完整包使用 `deepseek-balance-monitor-*-linux-x86_64.tar.gz`，独立 Plasma 小组件使用 `deepseek-balance-monitor-*-plasmoid.plasmoid`。发布版无需 Python 环境。
+
+### 可选 Plasma 小组件（Linux）
+
+Plasma 小组件是可选功能，需要 KDE Plasma 6。它从本机 `dsmon` 读取状态，不会直接接收 API Key。
+
+1. 从 [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases) 下载 `deepseek-balance-monitor-*-linux-x86_64.tar.gz`。
+2. 解压并运行安装脚本：
+
+   ```bash
+   tar -xzf deepseek-balance-monitor-*-linux-x86_64.tar.gz
+   cd deepseek-balance-monitor-*-linux-x86_64
+   sudo ./install.sh
+   systemctl --user enable --now dsmon.service
+   ```
+
+3. 在 Plasma 小组件选择器中添加 **DeepSeek Balance Monitor**。
+4. 打开小组件设置，输入 DeepSeek API Key，或使用 `dsmon set-key` 设置，然后点击 **保存**。
+5. 在小组件中点击 **查询** 可手动刷新余额。
+
+如果只需要小组件，可下载 `deepseek-balance-monitor-*-plasmoid.plasmoid` 并用 Plasma 小组件安装器安装。完整 Linux tar 包中也包含同一个小组件，路径为 `plasmoid/`。
 
 ### 可选 Rainmeter 小工具（Windows）
 
@@ -68,7 +93,7 @@ Rainmeter 桌面小工具是可选功能。它通过本地地址 `127.0.0.1:1765
 
 1. 从 [rainmeter.net](https://www.rainmeter.net/) 下载并安装 Rainmeter。
 2. 运行任意 Windows 版本（Python 或 Rust）——本地状态接口会自动启动。
-3. 从 [Releases](https://github.com/SrtaEstrella/DeepSeekBalanceMonitor/releases) 下载 `deepseek-balance-monitor-*-rainmeter.rmskin`。
+3. 从 [Releases](https://github.com/wenyinos/DeepSeekBalanceMonitor/releases) 下载 `deepseek-balance-monitor-*-rainmeter.rmskin`。
 4. 双击 `.rmskin` 安装皮肤。
 5. 在 Rainmeter 中加载 `DeepSeekBalanceMonitor\DeepSeekBalanceMonitor.ini`（英文版用 `DeepSeekBalanceMonitor.en.ini`）。
 

--- a/rust-linux/Cargo.lock
+++ b/rust-linux/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "dsmon"
-version = "1.2.0"
+version = "1.2.5"
 dependencies = [
  "chrono",
  "indexmap",

--- a/rust-linux/Cargo.toml
+++ b/rust-linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsmon"
-version = "1.2.0"
+version = "1.2.5"
 edition = "2021"
 rust-version = "1.77.2"
 description = "Linux CLI usage monitor for the DeepSeek API"

--- a/rust-linux/plasmoid/package/contents/config/main.xml
+++ b/rust-linux/plasmoid/package/contents/config/main.xml
@@ -5,7 +5,7 @@
   <kcfgfile name=""/>
   <group name="General">
     <entry name="language" type="String">
-      <default>en</default>
+      <default>zh</default>
     </entry>
   </group>
 </kcfg>

--- a/rust-linux/plasmoid/package/contents/ui/configGeneral.qml
+++ b/rust-linux/plasmoid/package/contents/ui/configGeneral.qml
@@ -8,17 +8,18 @@ import org.kde.plasma.plasma5support as Plasma5Support
 KCM.SimpleKCM {
     id: page
 
-    property string cfg_language: systemLanguage()
-    property string cfg_languageDefault: systemLanguage()
+    property string cfg_language: "zh"
+    property string cfg_languageDefault: "zh"
     property bool cfg_expanding: false
     property int cfg_length: 0
     property string statusText: ""
     property bool busy: false
+    property bool loadingConfig: true
     property bool hasStoredApiKey: false
     property string loadedApiKey: ""
     property bool savingBatch: false
     property var saveCommands: []
-    readonly property string uiLanguage: languageCombo.currentValue || systemLanguage()
+    readonly property string uiLanguage: normalizedLanguage(cfg_language)
 
     function shellQuote(value) {
         return "'" + String(value).replace(/'/g, "'\\''") + "'"
@@ -55,6 +56,16 @@ KCM.SimpleKCM {
         return String(localeName).indexOf("zh") === 0 ? "zh" : "en"
     }
 
+    function normalizedLanguage(value) {
+        return value === "zh" || value === "en" ? value : "zh"
+    }
+
+    onCfg_languageChanged: {
+        if (!loadingConfig && (cfg_language === "zh" || cfg_language === "en")) {
+            runCommand("/usr/local/bin/dsmon set " + shellQuote("ui-language") + " " + shellQuote(cfg_language))
+        }
+    }
+
     function tr(key) {
         var zh = {
             loading: "正在加载...",
@@ -83,6 +94,8 @@ KCM.SimpleKCM {
             logRetention: "日志和记录保留天数：",
             exportPath: "数据导出路径：",
             proxy: "HTTP/HTTPS 代理：",
+            proxyEnable: "启用 HTTP/HTTPS 代理",
+            proxyPlaceholder: "代理地址",
             theme: "图标主题：",
             themeDefault: "默认",
             themeContrast: "高对比",
@@ -125,6 +138,8 @@ KCM.SimpleKCM {
             logRetention: "Log & record retention (days):",
             exportPath: "Export path:",
             proxy: "HTTP/HTTPS proxy:",
+            proxyEnable: "Enable HTTP/HTTPS proxy",
+            proxyPlaceholder: "Proxy address",
             theme: "Icon theme:",
             themeDefault: "Default",
             themeContrast: "High Contrast",
@@ -172,18 +187,20 @@ KCM.SimpleKCM {
         }
         busy = true
         statusText = tr("saving")
+        cfg_language = normalizedLanguage(languageCombo.currentValue)
         saveCommands = []
         if (apiKeyArg === "demo") {
             saveCommands.push("/usr/local/bin/dsmon set-key " + shellQuote("demo"))
         }
         queueSetCommand("interval", [String(intervalSpin.value)])
         queueSetCommand("threshold", [threshold])
-        queueSetCommand("ui-language", [languageCombo.currentValue])
+        queueSetCommand("ui-language", [cfg_language])
         queueSetCommand("auto-start", [autoStartCheck.checked ? "true" : "false"])
         queueSetCommand("alert-mode", [alertModeCombo.currentValue])
         queueSetCommand("api-alert-enabled", [apiAlertCheck.checked ? "true" : "false"])
         queueSetCommand("retention-days", [String(logRetentionSpin.value)])
         queueSetCommand("export-path", [exportPathField.text.trim()])
+        queueSetCommand("proxy-enabled", [proxyEnableCheck.checked ? "true" : "false"])
         queueSetCommand("http-proxy", [proxyField.text.trim()])
         queueSetCommand("theme", [themeCombo.currentValue])
         queueSetCommand("icon-stroke", [iconStrokeCheck.checked ? "true" : "false"])
@@ -213,6 +230,7 @@ KCM.SimpleKCM {
         apiAlertCheck.checked = config.api_alert_enabled === undefined ? true : !!config.api_alert_enabled
         logRetentionSpin.value = config.retention_days || 30
         exportPathField.text = config.export_path || ""
+        proxyEnableCheck.checked = !!config.proxy_enabled
         proxyField.text = config.http_proxy || ""
         var themeIndex = themeCombo.indexOfValue(config.theme || "default")
         themeCombo.currentIndex = themeIndex >= 0 ? themeIndex : 0
@@ -222,14 +240,18 @@ KCM.SimpleKCM {
         lowColorField.text = colors.low || "b9463c"
         degradedColorField.text = colors.degraded || "78695a"
         noDataColorField.text = colors.nodata || "69696e"
-        var selectedLanguage = config.ui_language === "zh" || config.ui_language === "en" ? config.ui_language : systemLanguage()
+        var selectedLanguage = normalizedLanguage(config.ui_language)
+        loadingConfig = true
+        cfg_language = selectedLanguage
         var index = languageCombo.indexOfValue(selectedLanguage)
         languageCombo.currentIndex = index >= 0 ? index : 0
+        loadingConfig = false
         statusText = tr("loaded")
     }
 
     Component.onCompleted: {
-        var index = languageCombo.indexOfValue(systemLanguage())
+        loadingConfig = true
+        var index = languageCombo.indexOfValue(normalizedLanguage(cfg_language))
         if (index >= 0) {
             languageCombo.currentIndex = index
         }
@@ -248,6 +270,7 @@ KCM.SimpleKCM {
                 try {
                     applyConfig(stdout)
                 } catch (error) {
+                    loadingConfig = false
                     statusText = tr("loadFailed") + error
                 }
             } else if (savingBatch) {
@@ -309,6 +332,11 @@ KCM.SimpleKCM {
                 { text: "English", value: "en" },
                 { text: "中文", value: "zh" }
             ]
+            onCurrentValueChanged: {
+                if (!loadingConfig && (currentValue === "zh" || currentValue === "en")) {
+                    cfg_language = currentValue
+                }
+            }
         }
 
         QtControls.CheckBox {
@@ -360,7 +388,13 @@ KCM.SimpleKCM {
             id: proxyField
             Kirigami.FormData.label: tr("proxy")
             Layout.fillWidth: true
-            placeholderText: "http://127.0.0.1:7890"
+            enabled: proxyEnableCheck.checked
+            placeholderText: tr("proxyPlaceholder")
+        }
+
+        QtControls.CheckBox {
+            id: proxyEnableCheck
+            text: tr("proxyEnable")
         }
 
         QtControls.ComboBox {

--- a/rust-linux/plasmoid/package/contents/ui/main.qml
+++ b/rust-linux/plasmoid/package/contents/ui/main.qml
@@ -63,7 +63,7 @@ PlasmoidItem {
         ? Kirigami.Theme.negativeTextColor
         : (serviceDegraded ? warmGray : Kirigami.Theme.positiveTextColor)
     readonly property string balanceNumberColor: iconFill
-    readonly property string iconFill: checking ? iconColor("nodata") : (daemonChecked && !daemonRunning ? iconColor("low") : (ok ? (serviceDegraded ? iconColor("degraded") : (lowBalance ? iconColor("low") : iconColor("ok"))) : iconColor(configured ? "low" : "nodata")))
+    readonly property string iconFill: checking ? iconColor("nodata") : (daemonChecked && !daemonRunning ? iconColor("low") : (ok ? (lowBalance ? iconColor("low") : (serviceDegraded ? iconColor("degraded") : iconColor("ok"))) : iconColor(configured ? "low" : "nodata")))
     readonly property color iconTextColor: textColor(iconFill)
 
     function runCommand(command) {
@@ -149,6 +149,7 @@ PlasmoidItem {
             queryError: "查询出错",
             notChecked: "尚未查询",
             serviceStatus: "DeepSeek API 服务状态：",
+            rainmeterServiceLabel: "API 服务状态",
             serviceNormal: "服务正常",
             statusMinor: "轻微异常",
             statusMajor: "严重异常",
@@ -171,7 +172,11 @@ PlasmoidItem {
             balanceErrorTitle: "余额查询失败",
             daemonStopped: "dsmon 后台进程未运行，请启动 dsmon.service。",
             dailyRate: "日均消耗",
-            estimated: "预计可用"
+            estimated: "预计可用",
+            fallbackBalanceLine: "⚠ 请打开原进程",
+            fallbackLastCheck: "尚未查询",
+            fallbackServiceStatusLine: "⚪ 未连接",
+            fallbackEstimatedLine: "📊 等待数据"
         }
         var en = {
             title: "DeepSeek Balance Monitor",
@@ -193,6 +198,7 @@ PlasmoidItem {
             queryError: "Query error",
             notChecked: "Not checked",
             serviceStatus: "DeepSeek API Status:",
+            rainmeterServiceLabel: "API Status",
             serviceNormal: "All Systems Operational",
             statusMinor: "Minor Outage",
             statusMajor: "Major Outage",
@@ -215,7 +221,11 @@ PlasmoidItem {
             balanceErrorTitle: "Balance check failed",
             daemonStopped: "dsmon background process is not running. Start dsmon.service.",
             dailyRate: "Avg",
-            estimated: "Est."
+            estimated: "Est.",
+            fallbackBalanceLine: "⚠ Open the main app",
+            fallbackLastCheck: "Not checked",
+            fallbackServiceStatusLine: "⚪ Not Connected",
+            fallbackEstimatedLine: "📊 Waiting for data"
         }
         var table = language === "zh" ? zh : en
         return table[key] || key
@@ -375,6 +385,28 @@ PlasmoidItem {
         return language === "zh"
             ? tr("estimated") + " " + daysLeft + " 天 " + hoursRemainder + " 小时"
             : tr("estimated") + " " + daysLeft + "d " + hoursRemainder + "h remaining"
+    }
+
+    function rainmeterBalanceLine() {
+        if (daemonChecked && !daemonRunning) {
+            return tr("fallbackBalanceLine")
+        }
+        if (ok) {
+            return "💰 " + totalBalance + " " + totalCurrency
+        }
+        return "💰 -- CNY"
+    }
+
+    function rainmeterLastValue() {
+        return daemonChecked && !daemonRunning ? tr("fallbackLastCheck") : relativeLastCheck()
+    }
+
+    function rainmeterServiceValue() {
+        return daemonChecked && !daemonRunning ? tr("fallbackServiceStatusLine") : serviceStatusMarkup()
+    }
+
+    function rainmeterEstimatedLine() {
+        return daemonChecked && !daemonRunning ? tr("fallbackEstimatedLine") : "📊 " + estimatedAvailabilityText()
     }
 
     function balanceMessage() {
@@ -653,8 +685,7 @@ PlasmoidItem {
 
                 PlasmaExtras.ShadowedLabel {
                     Layout.fillWidth: true
-                    text: "💰 " + root.coloredNumber(root.totalBalance) + " " + root.htmlEscape(root.totalCurrency)
-                    textFormat: Text.RichText
+                    text: root.rainmeterBalanceLine()
                     color: root.glassTextColor
                     font.bold: true
                     font.pointSize: root.balanceTextPointSize
@@ -687,9 +718,11 @@ PlasmoidItem {
 
             PlasmaExtras.ShadowedLabel {
                 Layout.fillWidth: true
-                text: root.statusLine
+                visible: false
+                text: ""
                 color: root.glassTextColor
                 font.pointSize: 11
+                Layout.preferredHeight: 0
                 wrapMode: Text.WordWrap
                 maximumLineCount: 2
                 elide: Text.ElideRight
@@ -702,19 +735,19 @@ PlasmoidItem {
                 columnSpacing: Kirigami.Units.largeSpacing
 
                 PlasmaExtras.ShadowedLabel {
-                    text: "🕐 " + tr("lastCheck")
+                    text: "🕐 " + tr("lastCheck") + root.labelSeparator()
                     color: root.glassTextColor
                     font.pointSize: 10
                 }
                 PlasmaExtras.ShadowedLabel {
                     Layout.fillWidth: true
-                    text: root.lastCheck
+                    text: root.rainmeterLastValue()
                     color: root.glassTextColor
                     font.pointSize: 10
                     elide: Text.ElideRight
                 }
                 PlasmaExtras.ShadowedLabel {
-                    text: "📡 " + tr("serviceStatus")
+                    text: "📡 " + tr("rainmeterServiceLabel") + root.labelSeparator()
                     color: root.glassTextColor
                     font.pointSize: 10
                 }
@@ -724,7 +757,7 @@ PlasmoidItem {
 
                     PlasmaExtras.ShadowedLabel {
                         Layout.fillWidth: true
-                        text: root.serviceStatusEmoji() + " " + root.serviceStatusText()
+                        text: root.rainmeterServiceValue()
                         color: root.glassTextColor
                         font.pointSize: 10
                         elide: Text.ElideRight
@@ -734,7 +767,7 @@ PlasmoidItem {
 
             PlasmaExtras.ShadowedLabel {
                 Layout.fillWidth: true
-                text: "📊 " + root.estimatedAvailabilityText()
+                text: root.rainmeterEstimatedLine()
                 color: root.glassTextColor
                 font.bold: true
                 font.pointSize: root.balanceTextPointSize

--- a/rust-linux/plasmoid/package/metadata.json
+++ b/rust-linux/plasmoid/package/metadata.json
@@ -12,7 +12,7 @@
     "Id": "com.github.wenyinos.deepseek-balance-monitor",
     "License": "MIT",
     "Name": "DeepSeek Balance Monitor",
-    "Version": "1.2.0",
+    "Version": "1.2.5",
     "Website": "https://github.com/wenyinos/DeepSeekBalanceMonitor"
   },
   "X-Plasma-API-Minimum-Version": "6.0"

--- a/rust-linux/src/main.rs
+++ b/rust-linux/src/main.rs
@@ -46,6 +46,8 @@ struct AppConfig {
     export_path: String,
     #[serde(default)]
     http_proxy: String,
+    #[serde(default)]
+    proxy_enabled: bool,
     #[serde(default = "default_theme")]
     theme: String,
     #[serde(default)]
@@ -70,6 +72,7 @@ impl Default for AppConfig {
             retention_days: default_retention_days(),
             export_path: String::new(),
             http_proxy: String::new(),
+            proxy_enabled: false,
             theme: default_theme(),
             icon_colors: BTreeMap::new(),
             icon_stroke: false,
@@ -138,6 +141,7 @@ struct WidgetStatus {
     threshold_yuan: f64,
     api_alert_enabled: bool,
     retention_days: u64,
+    proxy_enabled: bool,
     language: String,
     ui_language: String,
     theme: String,
@@ -177,32 +181,6 @@ struct ApiBalanceInfo {
     granted_balance: String,
     #[serde(default)]
     topped_up_balance: String,
-}
-
-#[derive(Deserialize, Default)]
-struct StatusInfo {
-    #[serde(default)]
-    indicator: String,
-}
-
-#[derive(Deserialize)]
-struct StatusPayload {
-    #[serde(default)]
-    status: StatusInfo,
-}
-
-#[derive(Deserialize)]
-struct ComponentsPayload {
-    #[serde(default)]
-    components: Vec<ComponentStatus>,
-}
-
-#[derive(Deserialize)]
-struct ComponentStatus {
-    #[serde(default)]
-    name: String,
-    #[serde(default)]
-    status: String,
 }
 
 fn main() {
@@ -264,7 +242,7 @@ fn check_once() -> Result<(), (i32, String)> {
         log_line("Demo balance check succeeded").map_err(fail)?;
         return Ok(());
     }
-    let service_status = fetch_service_status(&config.http_proxy);
+    let service_status = fetch_service_status(effective_http_proxy(&config));
     if key.is_empty() {
         ensure_config_file().map_err(fail)?;
         print_status(
@@ -277,7 +255,7 @@ fn check_once() -> Result<(), (i32, String)> {
         return Err((2, String::new()));
     }
     let api_key = key.chars().filter(|c| c.is_ascii()).collect::<String>();
-    match fetch_balance(&api_key, &config.http_proxy) {
+    match fetch_balance(&api_key, effective_http_proxy(&config)) {
         Ok(balances) => {
             save_balance_history(&balances, &service_status).map_err(fail)?;
             print_status(
@@ -335,7 +313,7 @@ fn run_daemon() -> Result<(), (i32, String)> {
         let service_status = if demo_mode {
             "none".to_string()
         } else {
-            fetch_service_status(&config.http_proxy)
+            fetch_service_status(effective_http_proxy(&config))
         };
         if !last_service_status.is_empty() && service_status != last_service_status {
             log_line(&format!(
@@ -350,7 +328,7 @@ fn run_daemon() -> Result<(), (i32, String)> {
             demo::prepare(&conn).map_err(fail)?;
             demo::balances(&conn)
         } else {
-            fetch_balance(&api_key, &config.http_proxy)
+            fetch_balance(&api_key, effective_http_proxy(&config))
         };
         match balance_result {
             Ok(balances) => {
@@ -448,7 +426,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
     let service_status = if demo_mode {
         "none".to_string()
     } else {
-        fetch_service_status(&config.http_proxy)
+        fetch_service_status(effective_http_proxy(&config))
     };
     let service_degraded = is_service_degraded(&service_status);
     let latest_consumption_rate = if let Some(conn) = demo_conn.as_ref() {
@@ -472,6 +450,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
             threshold_yuan: config.threshold_yuan,
             api_alert_enabled: config.api_alert_enabled,
             retention_days: config.retention_days,
+            proxy_enabled: config.proxy_enabled,
             language: config.language.clone(),
             ui_language: config.ui_language.clone(),
             theme: config.theme.clone(),
@@ -503,6 +482,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
             threshold_yuan: config.threshold_yuan,
             api_alert_enabled: config.api_alert_enabled,
             retention_days: config.retention_days,
+            proxy_enabled: config.proxy_enabled,
             language: config.language.clone(),
             ui_language: config.ui_language.clone(),
             theme: config.theme.clone(),
@@ -520,7 +500,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
         });
     }
     let api_key = key.chars().filter(|c| c.is_ascii()).collect::<String>();
-    match fetch_balance(&api_key, &config.http_proxy) {
+    match fetch_balance(&api_key, effective_http_proxy(&config)) {
         Ok(balances) => {
             save_balance_history(&balances, &service_status).map_err(fail)?;
             let (total_currency, total_balance) = preferred_balance(&balances)
@@ -536,6 +516,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
                 threshold_yuan: config.threshold_yuan,
                 api_alert_enabled: config.api_alert_enabled,
                 retention_days: config.retention_days,
+                proxy_enabled: config.proxy_enabled,
                 language: config.language.clone(),
                 ui_language: config.ui_language.clone(),
                 theme: config.theme.clone(),
@@ -570,6 +551,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
                     threshold_yuan: config.threshold_yuan,
                     api_alert_enabled: config.api_alert_enabled,
                     retention_days: config.retention_days,
+                    proxy_enabled: config.proxy_enabled,
                     language: config.language.clone(),
                     ui_language: config.ui_language.clone(),
                     theme: config.theme.clone(),
@@ -598,6 +580,7 @@ fn print_widget_status() -> Result<(), (i32, String)> {
                     threshold_yuan: config.threshold_yuan,
                     api_alert_enabled: config.api_alert_enabled,
                     retention_days: config.retention_days,
+                    proxy_enabled: config.proxy_enabled,
                     language: config.language.clone(),
                     ui_language: config.ui_language.clone(),
                     theme: config.theme.clone(),
@@ -818,14 +801,14 @@ fn consumption_rate(hours: i64) -> Result<Option<ConsumptionRate>, String> {
 }
 
 fn consumption_rate_with_fallback(retention_days: u64) -> Result<Option<ConsumptionRate>, String> {
-    if let Some(rate) = consumption_rate(24)? {
+    if let Some(rate) = consumption_rate(7 * 24)? {
         return Ok(Some(rate));
     }
     let fallback_hours = retention_days
         .max(1)
         .saturating_mul(24)
         .min(i64::MAX as u64) as i64;
-    if fallback_hours <= 24 {
+    if fallback_hours <= 7 * 24 {
         return Ok(None);
     }
     consumption_rate(fallback_hours)
@@ -838,11 +821,11 @@ fn consumption_rate_from_records(
         return Ok(None);
     }
     let mut intervals = Vec::new();
-    let mut start_total = records[0].total;
+    let mut start_total = records[0].topped;
     let mut start_time = records[0].timestamp.as_str();
     let mut previous_total = start_total;
     for index in 1..records.len() {
-        let current_total = records[index].total;
+        let current_total = records[index].topped;
         if current_total > previous_total {
             intervals.push((
                 start_total,
@@ -887,7 +870,7 @@ fn consumption_rate_from_records(
     let latest = records.last().expect("records length already checked");
     Ok(Some(ConsumptionRate {
         daily_rate,
-        hours_left: latest.total / daily_rate * 24.0,
+        hours_left: latest.topped / daily_rate * 24.0,
         currency: latest.currency.clone(),
     }))
 }
@@ -942,7 +925,7 @@ fn set_key(args: &[String]) -> Result<(), (i32, String)> {
 fn set_config_field(args: &[String]) -> Result<(), (i32, String)> {
     if args.len() < 2 {
         return Err(fail(
-            "Usage: dsmon set <field> <value>\nFields: interval, threshold, ui-language, auto-start, alert-mode, api-alert-enabled, retention-days, export-path, http-proxy, theme, icon-stroke, icon-colors, color-ok, color-low, color-degraded, color-nodata",
+            "Usage: dsmon set <field> <value>\nFields: interval, threshold, ui-language, auto-start, alert-mode, api-alert-enabled, retention-days, export-path, http-proxy, proxy-enabled, theme, icon-stroke, icon-colors, color-ok, color-low, color-degraded, color-nodata",
         ));
     }
     let mut config = load_config().unwrap_or_default();
@@ -1013,6 +996,9 @@ fn apply_config_field(
         }
         "http-proxy" | "http_proxy" | "proxy" => {
             config.http_proxy = value.to_string();
+        }
+        "proxy-enabled" | "proxy_enabled" => {
+            config.proxy_enabled = parse_bool_arg(value)?;
         }
         "theme" => {
             config.theme = parse_theme_arg(value)?;
@@ -1163,13 +1149,9 @@ fn fetch_service_status(http_proxy: &str) -> String {
     let Ok(client) = http_client(Duration::from_secs(10), http_proxy) else {
         return "unknown".to_string();
     };
-    let mut status = fetch_overall_status(&client).unwrap_or("unknown");
-    if let Some(api_status) = fetch_api_component_status(&client) {
-        if status_rank(api_status) > status_rank(status) {
-            status = api_status;
-        }
-    }
-    status.to_string()
+    fetch_flashduty_api_status(&client)
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 fn http_client(timeout: Duration, http_proxy: &str) -> Result<reqwest::blocking::Client, String> {
@@ -1181,35 +1163,52 @@ fn http_client(timeout: Duration, http_proxy: &str) -> Result<reqwest::blocking:
     builder.build().map_err(|e| e.to_string())
 }
 
-fn fetch_overall_status(client: &reqwest::blocking::Client) -> Option<&'static str> {
-    let payload: StatusPayload = client
-        .get("https://status.deepseek.com/api/v2/status.json")
-        .header("Accept", "application/json")
-        .send()
-        .ok()?
-        .error_for_status()
-        .ok()?
-        .json()
-        .ok()?;
-    Some(normalize_service_status(&payload.status.indicator))
+fn effective_http_proxy(config: &AppConfig) -> &str {
+    if config.proxy_enabled {
+        config.http_proxy.trim()
+    } else {
+        ""
+    }
 }
 
-fn fetch_api_component_status(client: &reqwest::blocking::Client) -> Option<&'static str> {
-    let payload: ComponentsPayload = client
-        .get("https://status.deepseek.com/api/v2/components.json")
-        .header("Accept", "application/json")
+fn fetch_flashduty_api_status(client: &reqwest::blocking::Client) -> Option<&'static str> {
+    let html = client
+        .get("https://status.flashcat.cloud/deepseek")
+        .header("Accept", "text/html,*/*")
+        .header("User-Agent", "Mozilla/5.0")
         .send()
         .ok()?
         .error_for_status()
         .ok()?
-        .json()
+        .text()
         .ok()?;
-    payload
-        .components
-        .into_iter()
-        .filter(|item| item.name.to_ascii_lowercase().contains("api"))
-        .map(|item| normalize_service_status(&item.status))
+    Some(parse_flashduty_api_status(&html))
+}
+
+fn parse_flashduty_api_status(html: &str) -> &'static str {
+    let full = html.replace("\\\"", "\"");
+    full.split("\"name\"")
+        .skip(1)
+        .filter_map(|part| {
+            let name = json_string_after_key(part, "")?;
+            if name.to_ascii_lowercase().contains("api") {
+                json_string_after_key(part, "\"status\"").map(normalize_service_status)
+            } else {
+                None
+            }
+        })
         .max_by_key(|status| status_rank(status))
+        .unwrap_or("none")
+}
+
+fn json_string_after_key<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+    let text = if key.is_empty() {
+        text
+    } else {
+        &text[text.find(key)? + key.len()..]
+    };
+    let start = text[text.find(':')? + 1..].trim_start().strip_prefix('"')?;
+    start.split('"').next()
 }
 
 fn print_status(
@@ -1291,9 +1290,9 @@ fn is_service_degraded(status: &str) -> bool {
 fn normalize_service_status(value: &str) -> &'static str {
     match value {
         "none" | "operational" => "none",
-        "minor" | "degraded_performance" => "minor",
+        "minor" | "degraded" | "degraded_performance" => "minor",
         "major" | "partial_outage" => "major",
-        "critical" | "major_outage" => "critical",
+        "critical" | "full_outage" | "major_outage" => "critical",
         "maintenance" | "under_maintenance" => "maintenance",
         _ => "unknown",
     }
@@ -1958,16 +1957,7 @@ fn default_lang() -> String {
 }
 
 fn default_ui_lang() -> String {
-    let locale = ["LC_ALL", "LC_MESSAGES", "LANG"]
-        .iter()
-        .filter_map(|key| std::env::var(key).ok())
-        .map(|value| value.trim().to_string())
-        .find(|value| !value.is_empty());
-    match locale {
-        Some(value) if value.to_ascii_lowercase().starts_with("zh") => "zh".to_string(),
-        Some(_) => "en".to_string(),
-        None => "zh".to_string(),
-    }
+    "zh".to_string()
 }
 
 fn default_api_alert_enabled() -> bool {
@@ -2081,10 +2071,11 @@ mod tests {
 
         let qml = include_str!("../plasmoid/package/contents/ui/main.qml");
         assert!(qml.contains("function estimatedAvailabilityText()"));
+        assert!(qml.contains("function rainmeterBalanceLine()"));
         assert!(qml.contains("function relativeLastCheck()"));
         assert!(qml.contains("lines.push(\"💰 \""));
         assert!(qml.contains("lines.push(\"📡 \""));
-        assert!(qml.contains("text: \"📊 \" + root.estimatedAvailabilityText()"));
+        assert!(qml.contains("text: root.rainmeterEstimatedLine()"));
         assert!(!qml.contains("text: tr(\"balances\")"));
         assert!(!qml.contains("model: Object.keys(root.balances)"));
 

--- a/rust-windows/Cargo.lock
+++ b/rust-windows/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "deepseek-balance-monitor"
-version = "1.2.0"
+version = "1.2.5"
 dependencies = [
  "chrono",
  "image",

--- a/rust-windows/Cargo.toml
+++ b/rust-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-balance-monitor"
-version = "1.2.0"
+version = "1.2.5"
 edition = "2021"
 rust-version = "1.77.2"
 description = "Windows tray balance monitor for the DeepSeek API"

--- a/rust-windows/app.manifest
+++ b/rust-windows/app.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.2.0.0"
+    version="1.2.5.0"
     processorArchitecture="*"
     name="DeepSeekBalanceMonitor"
     type="win32" />

--- a/rust-windows/src/main.rs
+++ b/rust-windows/src/main.rs
@@ -231,6 +231,8 @@ mod windows_app {
         export_path: String,
         #[serde(default)]
         http_proxy: String,
+        #[serde(default)]
+        proxy_enabled: bool,
         #[serde(default = "default_theme")]
         theme: String,
         #[serde(default)]
@@ -255,6 +257,7 @@ mod windows_app {
                 retention_days: default_retention_days(),
                 export_path: String::new(),
                 http_proxy: String::new(),
+                proxy_enabled: false,
                 theme: default_theme(),
                 icon_colors: BTreeMap::new(),
                 icon_stroke: false,
@@ -415,32 +418,6 @@ mod windows_app {
         granted_balance: String,
         #[serde(default)]
         topped_up_balance: String,
-    }
-
-    #[derive(Deserialize, Default)]
-    struct StatusInfo {
-        #[serde(default)]
-        indicator: String,
-    }
-
-    #[derive(Deserialize)]
-    struct StatusPayload {
-        #[serde(default)]
-        status: StatusInfo,
-    }
-
-    #[derive(Deserialize)]
-    struct ComponentsPayload {
-        #[serde(default)]
-        components: Vec<ComponentStatus>,
-    }
-
-    #[derive(Deserialize)]
-    struct ComponentStatus {
-        #[serde(default)]
-        name: String,
-        #[serde(default)]
-        status: String,
     }
 
     fn default_currency() -> String {
@@ -990,7 +967,7 @@ mod windows_app {
             let service_status = if demo_mode {
                 "none".to_string()
             } else {
-                fetch_service_status(&config.http_proxy)
+                fetch_service_status(effective_http_proxy(&config))
             };
             let balance = if config.api_key.trim().is_empty() {
                 Err("No API Key configured".to_string())
@@ -1000,7 +977,7 @@ mod windows_app {
                     demo::balances(&conn)
                 })
             } else {
-                fetch_balance(&config.api_key, &config.http_proxy)
+                fetch_balance(&config.api_key, effective_http_proxy(&config))
             };
             if !demo_mode {
                 if let Ok(balances) = &balance {
@@ -1271,7 +1248,7 @@ mod windows_app {
         retention_input: nwg::TextInput,
         _export_path_label: nwg::Label,
         export_path_input: nwg::TextInput,
-        _proxy_label: nwg::Label,
+        proxy_enabled: nwg::CheckBox,
         proxy_input: nwg::TextInput,
         _theme_label: nwg::Label,
         theme_combo: nwg::ComboBox<&'static str>,
@@ -1322,7 +1299,7 @@ mod windows_app {
             let mut retention_input = Default::default();
             let mut export_path_label = Default::default();
             let mut export_path_input = Default::default();
-            let mut proxy_label = Default::default();
+            let mut proxy_enabled = Default::default();
             let mut proxy_input = Default::default();
             let mut theme_label = Default::default();
             let mut theme_combo = Default::default();
@@ -1468,14 +1445,20 @@ mod windows_app {
                 .size((100, 28))
                 .parent(&general_tab)
                 .build(&mut retention_input)?;
-            nwg::Label::builder()
-                .text(tr(lang, "proxy_label"))
+            nwg::CheckBox::builder()
+                .text(tr(lang, "proxy_enable"))
                 .position((20, 387))
-                .size((220, 22))
+                .size((220, 24))
                 .parent(&general_tab)
-                .build(&mut proxy_label)?;
+                .check_state(if config.proxy_enabled {
+                    checked
+                } else {
+                    unchecked
+                })
+                .build(&mut proxy_enabled)?;
             nwg::TextInput::builder()
                 .text(&config.http_proxy)
+                .placeholder_text(Some(tr(lang, "proxy_placeholder")))
                 .position((250, 383))
                 .size((230, 28))
                 .parent(&general_tab)
@@ -1579,11 +1562,10 @@ mod windows_app {
                 })
                 .build(&mut api_alerts)?;
 
-            let status = app.status_line();
             nwg::Label::builder()
-                .text(&status)
+                .text("")
                 .position((20, 586))
-                .size((460, 38))
+                .size((0, 0))
                 .parent(&general_tab)
                 .build(&mut status_label)?;
             let history_text = format_history_view(lang, config.retention_days, None);
@@ -1673,7 +1655,7 @@ mod windows_app {
                 retention_input,
                 _export_path_label: export_path_label,
                 export_path_input,
-                _proxy_label: proxy_label,
+                proxy_enabled,
                 proxy_input,
                 _theme_label: theme_label,
                 theme_combo,
@@ -1857,6 +1839,7 @@ mod windows_app {
             config.retention_days = retention_days;
             config.export_path = self.export_path_input.text().trim().to_string();
             config.http_proxy = self.proxy_input.text().trim().to_string();
+            config.proxy_enabled = self.proxy_enabled.check_state() == nwg::CheckBoxState::Checked;
             config.theme = match self.theme_combo.selection() {
                 Some(1) => "contrast",
                 Some(2) => "bright",
@@ -1891,28 +1874,7 @@ mod windows_app {
         }
     }
 
-    impl AppUi {
-        fn status_line(&self) -> String {
-            let state = self.state.lock().unwrap();
-            let lang = state.config.ui_language.as_str();
-            let last = state
-                .last_check
-                .map(|v| v.format("%Y-%m-%d %H:%M:%S").to_string())
-                .unwrap_or_else(|| tr(lang, "not_checked").to_string());
-            if let Some((code, balance)) = preferred_balance(&state.balances) {
-                format!(
-                    "{}: {} | {}: {} {}",
-                    tr(lang, "last_check"),
-                    last,
-                    tr(lang, "total_balance"),
-                    format_amount(balance.total_balance),
-                    code
-                )
-            } else {
-                format!("{}: {}", tr(lang, "last_check"), last)
-            }
-        }
-    }
+    impl AppUi {}
 
     fn fetch_balance(api_key: &str, http_proxy: &str) -> Result<BTreeMap<String, Balance>, String> {
         let client = http_client(Duration::from_secs(15), http_proxy)?;
@@ -1956,23 +1918,13 @@ mod windows_app {
                 return "unknown".to_string();
             }
         };
-        let mut status = match fetch_overall_status(&client) {
+        match fetch_flashduty_api_status(&client) {
             Ok(status) => status,
             Err(error) => {
-                log_line(&format!("API status overall check failed: {error}"));
-                "unknown"
+                log_line(&format!("API status check failed: {error}"));
+                "unknown".to_string()
             }
-        };
-        match fetch_api_component_status(&client) {
-            Ok(Some(api_status)) => {
-                if status == "unknown" || status_rank(api_status) > status_rank(status) {
-                    status = api_status;
-                }
-            }
-            Ok(None) => {}
-            Err(error) => log_line(&format!("API status component check failed: {error}")),
         }
-        status.to_string()
     }
 
     fn http_client(
@@ -1987,39 +1939,53 @@ mod windows_app {
         builder.build().map_err(|e| e.to_string())
     }
 
-    fn fetch_overall_status(client: &reqwest::blocking::Client) -> Result<&'static str, String> {
-        let response = client
-            .get("https://status.deepseek.com/api/v2/status.json")
-            .header("Accept", "application/json")
-            .send()
-            .map_err(|e| format!("request failed: {e}"))?;
-        let payload: StatusPayload = response
-            .error_for_status()
-            .map_err(|e| format!("HTTP status failed: {e}"))?
-            .json()
-            .map_err(|e| format!("JSON parse failed: {e}"))?;
-        Ok(normalize_service_status(&payload.status.indicator))
+    fn effective_http_proxy(config: &AppConfig) -> &str {
+        if config.proxy_enabled {
+            config.http_proxy.trim()
+        } else {
+            ""
+        }
     }
 
-    fn fetch_api_component_status(
-        client: &reqwest::blocking::Client,
-    ) -> Result<Option<&'static str>, String> {
+    fn fetch_flashduty_api_status(client: &reqwest::blocking::Client) -> Result<String, String> {
         let response = client
-            .get("https://status.deepseek.com/api/v2/components.json")
-            .header("Accept", "application/json")
+            .get("https://status.flashcat.cloud/deepseek")
+            .header("Accept", "text/html,*/*")
+            .header("User-Agent", "Mozilla/5.0")
             .send()
             .map_err(|e| format!("request failed: {e}"))?;
-        let payload: ComponentsPayload = response
+        let html = response
             .error_for_status()
             .map_err(|e| format!("HTTP status failed: {e}"))?
-            .json()
-            .map_err(|e| format!("JSON parse failed: {e}"))?;
-        Ok(payload
-            .components
-            .into_iter()
-            .filter(|item| item.name.to_ascii_lowercase().contains("api"))
-            .map(|item| normalize_service_status(&item.status))
-            .max_by_key(|status| status_rank(status)))
+            .text()
+            .map_err(|e| format!("HTML parse failed: {e}"))?;
+        Ok(parse_flashduty_api_status(&html).to_string())
+    }
+
+    fn parse_flashduty_api_status(html: &str) -> &'static str {
+        let full = html.replace("\\\"", "\"");
+        full.split("\"name\"")
+            .skip(1)
+            .filter_map(|part| {
+                let name = json_string_after_key(part, "")?;
+                if name.to_ascii_lowercase().contains("api") {
+                    json_string_after_key(part, "\"status\"").map(normalize_service_status)
+                } else {
+                    None
+                }
+            })
+            .max_by_key(|status| status_rank(status))
+            .unwrap_or("none")
+    }
+
+    fn json_string_after_key<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+        let text = if key.is_empty() {
+            text
+        } else {
+            &text[text.find(key)? + key.len()..]
+        };
+        let start = text[text.find(':')? + 1..].trim_start().strip_prefix('"')?;
+        start.split('"').next()
     }
 
     fn parse_amount(value: &str) -> f64 {
@@ -2045,9 +2011,9 @@ mod windows_app {
     fn normalize_service_status(value: &str) -> &'static str {
         match value {
             "none" | "operational" => "none",
-            "minor" | "degraded_performance" => "minor",
+            "minor" | "degraded" | "degraded_performance" => "minor",
             "major" | "partial_outage" => "major",
-            "critical" | "major_outage" => "critical",
+            "critical" | "full_outage" | "major_outage" => "critical",
             "maintenance" | "under_maintenance" => "maintenance",
             _ => "unknown",
         }
@@ -2860,14 +2826,14 @@ mod windows_app {
     fn consumption_rate_with_fallback(
         retention_days: u64,
     ) -> Result<Option<ConsumptionRate>, String> {
-        if let Some(rate) = consumption_rate(24)? {
+        if let Some(rate) = consumption_rate(7 * 24)? {
             return Ok(Some(rate));
         }
         let fallback_hours = retention_days
             .max(1)
             .saturating_mul(24)
             .min(i64::MAX as u64) as i64;
-        if fallback_hours <= 24 {
+        if fallback_hours <= 7 * 24 {
             return Ok(None);
         }
         consumption_rate(fallback_hours)
@@ -2880,11 +2846,11 @@ mod windows_app {
             return Ok(None);
         }
         let mut intervals = Vec::new();
-        let mut start_total = records[0].total;
+        let mut start_total = records[0].topped;
         let mut start_time = records[0].timestamp.as_str();
         let mut previous_total = start_total;
         for index in 1..records.len() {
-            let current_total = records[index].total;
+            let current_total = records[index].topped;
             if current_total > previous_total {
                 intervals.push((
                     start_total,
@@ -2931,7 +2897,7 @@ mod windows_app {
         let latest = records.last().expect("records length already checked");
         Ok(Some(ConsumptionRate {
             daily_rate,
-            hours_left: latest.total / daily_rate * 24.0,
+            hours_left: latest.topped / daily_rate * 24.0,
             currency: latest.currency.clone(),
         }))
     }
@@ -3320,7 +3286,7 @@ mod windows_app {
             ("en", "top_up") => "Top Up",
             ("en", "settings") => "Settings...",
             ("en", "quit") => "Quit",
-            ("en", "settings_title") => "DeepSeek Balance Monitor - Settings",
+            ("en", "settings_title") => "⚙️ Settings",
             ("en", "settings_tab") => "Settings",
             ("en", "history_tab") => "History",
             ("en", "api_key_label") => "DeepSeek API Key:",
@@ -3337,6 +3303,8 @@ mod windows_app {
             ("en", "retention_label") => "Log & record retention (days):",
             ("en", "export_path_label") => "Export path:",
             ("en", "proxy_label") => "HTTP/HTTPS proxy:",
+            ("en", "proxy_enable") => "Enable HTTP/HTTPS proxy",
+            ("en", "proxy_placeholder") => "Proxy address",
             ("en", "theme_label") => "Icon theme:",
             ("en", "theme_default") => "Default",
             ("en", "theme_contrast") => "High Contrast",
@@ -3423,7 +3391,7 @@ mod windows_app {
             (_, "top_up") => "充值",
             (_, "settings") => "设置...",
             (_, "quit") => "退出",
-            (_, "settings_title") => "DeepSeek Balance Monitor - 设置",
+            (_, "settings_title") => "⚙️ 设置",
             (_, "settings_tab") => "设置",
             (_, "history_tab") => "历史",
             (_, "api_key_label") => "DeepSeek API Key:",
@@ -3440,6 +3408,8 @@ mod windows_app {
             (_, "retention_label") => "日志和记录保留天数：",
             (_, "export_path_label") => "数据导出路径：",
             (_, "proxy_label") => "HTTP/HTTPS 代理：",
+            (_, "proxy_enable") => "启用 HTTP/HTTPS 代理",
+            (_, "proxy_placeholder") => "代理地址",
             (_, "theme_label") => "图标主题：",
             (_, "theme_default") => "默认",
             (_, "theme_contrast") => "高对比",


### PR DESCRIPTION
## Rust v1.2.5 (2026-05-12)

### Added

- Standalone Plasma widget release asset: `deepseek-balance-monitor-*-plasmoid.plasmoid`
- Linux release tarballs now include the same Plasma widget package under `plasmoid/`
- Linux release assets include `checksums.txt` for tarball verification

### Changed

- Plasma widget display now follows the Rainmeter layout: balance line, relative last-check time, API service status, and estimated remaining time
- Plasma widget language settings now sync `cfg_language` back to `ui_language`, so English/Chinese selection survives Plasma restarts
- Low-balance display colour now takes priority over API-degraded colour, matching Rainmeter accent rules
- Rust Linux and Rust Windows service-status checks now use the FlashDuty-backed DeepSeek status page
- Consumption estimates use topped-balance history over a 7-day window, with retention-period fallback when needed
- Proxy settings now include an explicit enable toggle while preserving the proxy address when disabled

### Fixed

- Fixed Linux Plasma language changes appearing to reset after restarting `plasmashell`
- Fixed removed DeepSeek status REST API usage in Rust ports
- Fixed Windows settings title/footer behaviour to match the v1.2 settings design