### PR TITLE
1.2.10 相对 1.2.6 的新特性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ target/
 .cargo/
 **/.cargo/
 *.rs.bk
-CLAUDE.md
-GEMINI.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,33 @@
-# Repository Guidelines
+# AGENTS.md
 
-## Project Structure & Module Organization
+跨平台 DeepSeek API 余额监控工具。**权威项目细节见 `CLAUDE.md`（架构、算法、i18n、密钥存储、多平台矩阵）**，本文件只列 agent 容易踩坑的高信号事实。
 
-本仓库是一个 Python Windows 托盘应用，用于监控 DeepSeek API 余额。运行时代码放在
-`src/`，`main.py` 只作为入口。`src/api_client.py` 负责余额接口请求，
-`src/config.py` 管理配置、日志和中英文文案，`src/icon_renderer.py` 生成托盘图标，
-`src/settings_dialog.py` 负责设置窗口，`src/app_state.py` 保存共享状态，
-`src/tray_app.py` 组装应用流程。构建和辅助脚本放在 `scripts/`，根目录保留
-`README.md`、`requirements.txt`、`preview_taskbar.png` 等项目级文件。
+## 多实现同步（最高优先级约定）
 
-## Build, Test, and Development Commands
+同一功能有 Python（`src/`、`main.py`）与 Rust 双实现，另有 Rainmeter（Windows）与 Plasma 6（Linux）小组件：
 
-```bash
-pip install -r requirements.txt
-python main.py
-python scripts/test_api.py YOUR_DEEPSEEK_API_KEY
-scripts\build_exe.bat
-```
+- 改 API 客户端 / 忙时速率算法 / 告警逻辑时，**必须同步检查 Python 与 Rust 两端**
+- `src/` 是 Python 运行时，`main.py` 仅入口，勿改动
 
-- `pip install -r requirements.txt`：安装运行依赖。
-- `python main.py`：从源码启动托盘应用。
-- `python scripts/test_api.py ...`：使用真实 API Key 验证 DeepSeek 接口连接。
-- `scripts\build_exe.bat`：生成图标并构建 Windows 单文件可执行程序。
+## 命令与工具链
 
-## Coding Style & Naming Conventions
+- Python 测试（与 CI 一致）：`python -m unittest discover -s tests -v`
+  - 单文件：`python -m unittest discover -s tests -p test_core.py`
+  - 测试文件无 `__main__` 入口，不能直接 `python tests/test_core.py`
+- Rust **工具链固定 1.77.2**（`rust-toolchain.toml` 强制），务必用 `cargo +1.77.2 ...`，勿用系统默认工具链：
+  - `cd rust-linux && cargo +1.77.2 test --locked` / `cargo +1.77.2 fmt --check`
+  - `cd rust-windows && cargo +1.77.2 build --release --target x86_64-pc-windows-msvc --locked`
+- Linux 安装产物为 `dsmon`（rust-linux crate 名）；CI 在 rockylinux:8 容器构建并检查 glibc 符号，保持 RHEL 8 兼容
 
-使用 Python 3.10+，缩进为 4 个空格。函数、变量和模块使用 `snake_case`，常量使用
-`UPPER_CASE`。保持现有的直接函数式写法，公共辅助函数优先补充类型标注。新增界面文案
-应写入 `src/config.py` 的 `_T` 翻译表，不要散落在各 UI 模块。修改时保持小范围，
-不要顺手重构无关代码。
+## 关键陷阱
 
-## Testing Guidelines
+- **API Key 永不写入 `config.json`**：Python 用 Fernet+SQLite（`src/secure_settings.py`），Rust 用 SQLite `secure_settings` 表；Opencode Go 凭据同样加密入库
+- Python 版 UI 文案集中在 `src/config.py` 的 `_T` 字典，新增文案必须加进去，不硬编码；CLI 输出固定英文
+- `get_consumption_rate()` 返回 `hourly_rate`（忙时小时速率），非旧版 `daily_rate`
+- API Key 设为 `demo` 会触发 rust-linux 演示模式（`src/demo.rs`）
+- Python 版 tkinter + pystray 双事件循环，改动时避免死锁
 
-当前没有正式测试目录。涉及 API 的改动，运行
-`python scripts/test_api.py YOUR_DEEPSEEK_API_KEY` 验证连接和响应解析。涉及 UI、配置、
-图标或托盘行为的改动，应在 Windows 上运行 `python main.py`，手动检查首次启动、设置
-保存/读取、托盘菜单、余额不足状态和退出流程。不要提交真实 API Key 或本地配置文件。
+## 发布触发
 
-## Commit & Pull Request Guidelines
-
-提交历史以简短说明为主，中文描述和 `fix:` 前缀都可接受。每次 commit 只做一件事，
-示例：`fix: handle empty balance response`、`优化设置窗口文案`。Pull Request 应说明
-用户可见变化、列出手动验证步骤、标明配置或 API 影响；如果改动托盘图标或设置窗口，
-附上截图。
-
-## Security & Configuration Tips
-
-配置文件位于 `%APPDATA%\DeepSeek Balance Monitor\config.json`，日志也写入同一目录。
-禁止在源码、脚本、截图或文档中硬编码 API Key、token 或其他密钥。`build/`、`dist/`、
-`*.spec`、`app_icon.ico`、日志等生成物应保持在版本控制之外。
+- tag `v*` → Python 构建（GitHub Actions）；`rust-v*` → Rust 构建
+- 发布 / 签名 / Rainmeter 打包细节见 `CLAUDE.md` 与 `CODE_SIGNING.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to DeepSeek Balance Monitor are documented here.
 
+## Rust v1.2.10 (2026-08-02)
+
+### Added
+
+- OpenCode Go quota display (Rust Windows and Rust Linux): scrapes the opencode.ai workspace dashboard and reports rolling (~5h), weekly, and monthly usage as used/remaining percentages with reset time
+- Windows: the settings dialog gains an "OpenCode Go" tab with workspace ID / auth cookie inputs and a manual refresh button
+- Linux: new `dsmon opencode-go` (query quota) and `dsmon opencode-go set <workspace_id> <auth_cookie>` (store credentials) CLI commands
+- OpenCode Go credentials are stored encrypted in the `secure_settings` table under dedicated keys (`opencode_go_workspace_id`, `opencode_go_auth_cookie`), never written to config.json
+
 ## Rust v1.2.6 (2026-06-08)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to DeepSeek Balance Monitor are documented here.
 
 - OpenCode Go quota display (Rust Windows and Rust Linux): scrapes the opencode.ai workspace dashboard and reports rolling (~5h), weekly, and monthly usage as used/remaining percentages with reset time
 - Windows: the settings dialog gains an "OpenCode Go" tab with workspace ID / auth cookie inputs and a manual refresh button
-- Linux: new `dsmon opencode-go` (query quota) and `dsmon opencode-go set <workspace_id> <auth_cookie>` (store credentials) CLI commands
+- Linux: new `dsmon opencode-go` (query quota), `dsmon opencode-go set <workspace_id> <auth_cookie>` (store credentials), and `dsmon opencode-go json` (JSON output) CLI commands
+- Linux: the Plasma 6 widget adds a dedicated "OpenCode Go" settings page showing quota, read directly from `dsmon opencode-go json`
 - OpenCode Go credentials are stored encrypted in the `secure_settings` table under dedicated keys (`opencode_go_workspace_id`, `opencode_go_auth_cookie`), never written to config.json
 
 ## Rust v1.2.6 (2026-06-08)

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -2,6 +2,15 @@
 
 所有值得记录的变更均记录于此。
 
+## Rust v1.2.10 (2026-08-02)
+
+### 新增
+
+- OpenCode Go 额度显示（Rust Windows 与 Rust Linux）：爬取 opencode.ai 工作区仪表板，报告 5 小时滚动 / 每周 / 每月三档用量的已用与剩余百分比及重置时间
+- Windows：设置窗口新增「OpenCode Go」标签页，可填写工作区 ID / Auth Cookie 并手动刷新
+- Linux：新增 `dsmon opencode-go`（查询额度）与 `dsmon opencode-go set <workspace_id> <auth_cookie>`（保存凭据）CLI 命令
+- OpenCode Go 凭据加密存储于 `secure_settings` 表（独立 key：`opencode_go_workspace_id`、`opencode_go_auth_cookie`），绝不写入 config.json
+
 ## Rust v1.2.6 (2026-06-08)
 
 ### 变更

--- a/CHANGELOG_zh.md
+++ b/CHANGELOG_zh.md
@@ -8,7 +8,8 @@
 
 - OpenCode Go 额度显示（Rust Windows 与 Rust Linux）：爬取 opencode.ai 工作区仪表板，报告 5 小时滚动 / 每周 / 每月三档用量的已用与剩余百分比及重置时间
 - Windows：设置窗口新增「OpenCode Go」标签页，可填写工作区 ID / Auth Cookie 并手动刷新
-- Linux：新增 `dsmon opencode-go`（查询额度）与 `dsmon opencode-go set <workspace_id> <auth_cookie>`（保存凭据）CLI 命令
+- Linux：新增 `dsmon opencode-go`（查询额度）、`dsmon opencode-go set <workspace_id> <auth_cookie>`（保存凭据）与 `dsmon opencode-go json`（JSON 输出）CLI 命令
+- Linux：Plasma 6 小组件新增独立的「OpenCode Go」设置页面展示额度，直接从 `dsmon opencode-go json` 读取
 - OpenCode Go 凭据加密存储于 `secure_settings` 表（独立 key：`opencode_go_workspace_id`、`opencode_go_auth_cookie`），绝不写入 config.json
 
 ## Rust v1.2.6 (2026-06-08)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ dsmon set <field> <value># 修改配置
 dsmon history [days]     # 查看历史
 dsmon history export [days] [currency|all] [path|-]  # 导出 CSV
 dsmon widget-status      # 输出 Plasma 小组件 JSON
+dsmon opencode-go        # 查询 OpenCode Go 额度
+dsmon opencode-go set <workspace_id> <auth_cookie>   # 加密保存凭据
 ```
 
 ## 高层架构
@@ -115,6 +117,14 @@ dsmon widget-status      # 输出 Plasma 小组件 JSON
 | Red | 余额不足或 API 错误 |
 | Warm Gray | API 服务降级 |
 | Gray | 尚未查询或未配置 Key |
+
+### Opencode Go 额度（两 Rust 平台）
+
+- 爬取 `https://opencode.ai/workspace/{workspace_id}/go` 页面（请求头 `Cookie: auth={auth_cookie}`），解析 **5h 滚动 / 每周 / 每月** 三档用量的已用百分比与重置秒数
+- 解析优先 SolidJS SSR 格式（`rollingUsage:$R[n]={usagePercent:X,resetInSec:Y}`），失败回退 `data-slot` HTML 格式；用字符串查找实现，**不引入 regex 依赖**
+- 凭据 `workspace_id` 与 `auth_cookie` **均加密存入 `secure_settings` 表**（独立 key `opencode_go_workspace_id` / `opencode_go_auth_cookie`，与 API Key 同一加密机制），**不写入 config.json**
+- 入口：rust-windows 设置窗口第三个「Opencode Go」标签页（可配置凭据 + 手动刷新）；rust-linux 为 `dsmon opencode-go` / `dsmon opencode-go set`
+- 凭据获取方式：workspace ID 在 opencode.ai 工作区 URL 中；auth cookie 在浏览器开发者工具 → Storage → Cookies 中查看
 
 ### API 端点与代理
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 项目概述
+
+跨平台 DeepSeek API 余额监控工具：托盘图标显示余额、余额不足告警、历史记录查看器、忙时消耗速率估算，附带 Rainmeter (Windows) 与 Plasma 6 (Linux) 桌面小组件。同一功能有 **Python 和 Rust 双实现**，改动逻辑时需注意多端同步。
+
+## 常用命令
+
+### Python 版（Windows / macOS）
+
+```bash
+pip install -r requirements.txt
+python main.py                          # 运行托盘应用（src/ 为运行时，main.py 仅入口）
+python -m unittest discover -s tests -v # 全部测试（与 CI 一致）
+python scripts/test_api.py YOUR_API_KEY # 真实 API 连接验证
+scripts\build_exe.bat                   # Windows 单文件 EXE
+cd src/mac && bash ../scripts/build_mac.sh   # macOS 应用
+```
+
+- 运行单个测试文件：`python -m unittest discover -s tests -p test_core.py`
+- 测试文件无 `__main__` 入口，不能直接 `python tests/test_core.py`
+
+### Rust 版（工具链固定 1.77.2，见「版本工具链」）
+
+```bash
+cd rust-linux && cargo +1.77.2 build --release --locked
+sudo ./install.sh                        # 安装 dsmon 到系统
+
+cd rust-windows && cargo +1.77.2 build --release --target x86_64-pc-windows-msvc --locked
+
+# 两个 crate 的 main.rs 均含 #[cfg(test)] 测试模块
+cd rust-linux && cargo +1.77.2 test --locked
+cd rust-linux && cargo +1.77.2 fmt --check   # CI 校验格式
+```
+
+### Linux CLI（安装后，`dsmon`）
+
+```bash
+dsmon check              # 查询余额
+dsmon daemon             # 守护进程模式
+dsmon set-key            # 设置 API Key
+dsmon set <field> <value># 修改配置
+dsmon history [days]     # 查看历史
+dsmon history export [days] [currency|all] [path|-]  # 导出 CSV
+dsmon widget-status      # 输出 Plasma 小组件 JSON
+```
+
+## 高层架构
+
+### 多平台实现矩阵
+
+| 平台 | 路径 | 技术栈 |
+|---|---|---|
+| Python Windows | `src/`, `main.py` | pystray + Tkinter，Windows 10+ |
+| Python macOS | `src/mac/`, `src/webview/` | rumps + pywebview，macOS 10.14+ |
+| Rust Windows | `rust-windows/` | native-windows-gui，Windows 7+ |
+| Rust Linux | `rust-linux/` | CLI + 守护进程 + Plasma 6 小组件 |
+
+### Python 核心模块（Windows）
+
+- `src/config.py`: 常量、i18n (`_T` 字典)、配置加载/保存、DPI 感知
+- `src/api_client.py`: 余额查询、服务状态检查、代理
+- `src/tray_app.py`: 托盘主循环、通知、菜单、余额调度
+- `src/app_state.py`: 共享状态（余额、配置、运行状态）
+- `src/icon_renderer.py`: 动态托盘图标（Pillow）
+- `src/settings_dialog.py` / `src/history_dialog.py`: 设置窗口 / 历史查看器
+- `src/storage.py`: SQLite、忙时切片消耗速率算法
+- `src/secure_settings.py`: Fernet + SQLite 加密存储 API Key
+- `src/rainmeter_server.py`: Rainmeter 本地 HTTP 接口
+
+### macOS 实现（两个设置界面并存）
+
+- `src/mac/main.py`: rumps 托盘应用
+- `src/mac/keystore.py`: Fernet/Keychain 加密 API Key
+- `src/webview/`: pywebview 设置窗口，由托盘应用以**子进程**启动（`python -m src.webview.main`），`bridge.py` 的 JsApi 与 Python 通信，用 `CONFIG_DIR/.settings_changed` 哨兵文件通知主进程
+- `src/mac/settings.py`: tkinter 回退设置窗口
+
+### Rust 实现
+
+- `rust-linux/src/main.rs`: 单文件包含 CLI、守护进程、忙时切片算法与 Plasma 小组件数据，含 `#[cfg(test)]` 测试模块
+- `rust-linux/src/demo.rs`: 演示模式数据生成（用 `demo` 作 API Key 触发）
+- `rust-windows/src/main.rs`: 原生 Windows GUI，结构类似 rust-linux
+
+### 桌面小组件
+
+- **Rainmeter**（仅 Windows）: 从 `127.0.0.1:17654` 读取本地状态接口，不直接持有 API Key。皮肤在 `rainmeter-widget/DeepSeekBalanceMonitor/`，支持中英文与高清（`.hd.ini`）变体
+- **Plasma 6**（仅 Linux）: `rust-linux/plasmoid/` 的 C++ 小组件，通过 `dsmon widget-status` 取数；语言切换会写回 `dsmon` 的 `ui_language`
+
+## 核心约定
+
+### 配置与密钥存储
+
+- 配置文件位置：Windows `%APPDATA%\DeepSeek Balance Monitor\config.json`；Linux `~/.config/deepseek-balance-monitor/config.json`；macOS `~/Library/Application Support/DeepSeek Balance Monitor/config.json`
+- **API Key 永不写入 config.json**，使用加密存储（Python: Fernet + SQLite；macOS: Keychain/Fernet；Rust: SQLite `secure_settings`）
+
+### i18n
+
+- Python 版所有 UI 文案集中在 `src/config.py` 的 `_T` 字典，新增文案必须加进去，不要硬编码
+- CLI（`dsmon`）输出固定英文，不随 `ui_language` 切换
+
+### 忙时消耗速率算法（v1.2.7+）
+
+- 忙时切片算法替代原有充值跳变检测：识别忙时区间（排除闲时/平直段），返回**忙时小时消耗速率**（CNY/小时）与预计可用忙时小时数
+- 调用 `get_consumption_rate()` 注意返回值语义：`hourly_rate` 而非旧 `daily_rate`
+- 显示格式统一——中文 `📊 忙时消耗 0.06/小时 | 预计可用 28 天 4 小时`；英文 `📊 Busy: 0.06/hr | Est. 28d 4h remaining`
+- Rainmeter 取 `estimated_line` 字段；Plasma 直接从 `consumption_rate` 计算；Rust 版已跟进此算法
+
+### 图标颜色状态
+
+| 颜色 | 含义 |
+|---|---|
+| Teal | 余额正常 |
+| Red | 余额不足或 API 错误 |
+| Warm Gray | API 服务降级 |
+| Gray | 尚未查询或未配置 Key |
+
+### API 端点与代理
+
+- `api.deepseek.com/user/balance` — 余额查询
+- `status.flashcat.cloud/deepseek` — FlashDuty 服务状态（RSC 解析），已弃用 `status.deepseek.com/api/v2`
+- 代理：`http_proxy` 配置项 + `proxy_enabled` 开关；禁用时保留代理地址不清除
+
+### 版本工具链
+
+- Rust 固定在 **1.77.2**：1.78+ 把 Windows 普通目标基线提升到 Windows 10，会破坏 Windows 7 支持
+- CI 中 Linux 构建在 `rockylinux:8` 容器进行并检查 glibc 符号，保持 RHEL 8 兼容；发布 tag `v*` 触发 Python 构建，`rust-v*` 触发 Rust
+
+## 注意事项
+
+- 修改 API 客户端时需**同步检查 Python 与 Rust 实现**
+- Python 版 tkinter + pystray 双事件循环，改动时注意避免死锁
+- Windows 7/8.1 根证书问题可运行 `scripts\update_windows_root_certs.bat`
+- macOS 构建脚本在 `src/mac` 下运行；改动 macOS 相关文件时遵循现有目录约束

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rainmeter widget preview
 
 Rust Linux-specific:
 - Rust Linux: `dsmon set-key` and `dsmon set <field> <value>`; daemon reloads config on each poll cycle; CLI stays English-only.
-- `dsmon opencode-go` prints OpenCode Go quota; `dsmon opencode-go set <workspace_id> <auth_cookie>` stores the credentials encrypted; `dsmon opencode-go json` emits machine-readable output.
+- `dsmon opencode-go` prints OpenCode Go quota; `dsmon opencode-go set "workspace_id" "auth_cookie"` stores the credentials encrypted — wrap both arguments in double quotes (auth cookies contain special characters); `dsmon opencode-go json` emits machine-readable output.
 - The Plasma 6 widget adds a dedicated "OpenCode Go" settings page, read directly from `dsmon opencode-go json`.
 - Plasma 6 widget: transparent liquid-glass desktop view with balance, last check, API service status, estimated availability, refresh control, and emoji status text.
 - Plasma 6 widget display is intentionally compact: the main desktop view shows a balance line, relative last-check time, DeepSeek API status, and estimated remaining time.
@@ -180,7 +180,7 @@ Useful Linux CLI commands:
 | `dsmon history [days]` | Print a balance history summary |
 | `dsmon history export [days] [currency\|all] [path\|-]` | Export history as CSV; `-` writes CSV to stdout |
 | `dsmon widget-status` | Print JSON status consumed by the Plasma widget |
-| `dsmon opencode-go` | Print OpenCode Go quota (5h/weekly/monthly usage); set credentials with `dsmon opencode-go set <workspace_id> <auth_cookie>` |
+| `dsmon opencode-go` | Print OpenCode Go quota (5h/weekly/monthly usage); set credentials with `dsmon opencode-go set "workspace_id" "auth_cookie"` — wrap both arguments in double quotes (auth cookies contain special characters) |
 
 **MacOS (`src/mac/`):**
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Rainmeter widget preview
 - Demo mode for testing without a real API key: developer tools panel on Py-Win/Py-Mac, `demo` API key trigger on Rust.
 - Encrypted API key storage: Fernet + SQLite on Py-Win, SQLite `secure_settings` on Rust, Keychain on Py-Mac.
 - Rainmeter desktop widget: local-only status interface; `.rmskin` release packaging. Supported on both Rust and Python Windows builds.
+- OpenCode Go quota display (Rust builds): scrapes the opencode.ai workspace dashboard for rolling (5h), weekly, and monthly usage; credentials stored encrypted in SQLite, never in config.json.
 
 Rust Linux-specific:
 - Rust Linux: `dsmon set-key` and `dsmon set <field> <value>`; daemon reloads config on each poll cycle; CLI stays English-only.
+- `dsmon opencode-go` prints OpenCode Go quota; `dsmon opencode-go set <workspace_id> <auth_cookie>` stores the credentials encrypted.
 - Plasma 6 widget: transparent liquid-glass desktop view with balance, last check, API service status, estimated availability, refresh control, and emoji status text.
 - Plasma 6 widget display is intentionally compact: the main desktop view shows a balance line, relative last-check time, DeepSeek API status, and estimated remaining time.
 - Refreshing the Linux Plasma widget model: balance, relative last check, API service status, and estimated availability now match the Rainmeter widget layout.
@@ -44,6 +46,7 @@ Rust Linux-specific:
 - **Balance details** — Left-click the icon to see balance (emoji-prefixed), consumption rate, API service status, and relative last-check time.
 - **History viewer** — Paginated table of all balance records with interactive trend chart and consumption rate analysis. CSV export.
 - **Settings** — API key (Fernet + SQLite encrypted storage), check interval, alert threshold, alert mode, icon theme, proxy, and more.
+- **OpenCode Go quota** (Rust builds) — A dedicated Settings tab (Windows) or `dsmon opencode-go` (Linux) shows rolling 5h/weekly/monthly usage from the opencode.ai dashboard, with encrypted credential storage.
 - **Demo mode** — `--demo` flag for testing without an API key, with a developer tools panel.
 - **Optional desktop widgets** — KDE Plasma 6 on Linux, and Rainmeter on Windows (Rust and Python builds both supported).
 - **Community ports** — Rust-Win (Win7+), Rust-Linux (CLI + Plasma 6 widget), Py-Mac (Keychain-secured, WebView settings UI).
@@ -176,6 +179,7 @@ Useful Linux CLI commands:
 | `dsmon history [days]` | Print a balance history summary |
 | `dsmon history export [days] [currency\|all] [path\|-]` | Export history as CSV; `-` writes CSV to stdout |
 | `dsmon widget-status` | Print JSON status consumed by the Plasma widget |
+| `dsmon opencode-go` | Print OpenCode Go quota (5h/weekly/monthly usage); set credentials with `dsmon opencode-go set <workspace_id> <auth_cookie>` |
 
 **MacOS (`src/mac/`):**
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Rainmeter widget preview
 
 Rust Linux-specific:
 - Rust Linux: `dsmon set-key` and `dsmon set <field> <value>`; daemon reloads config on each poll cycle; CLI stays English-only.
-- `dsmon opencode-go` prints OpenCode Go quota; `dsmon opencode-go set <workspace_id> <auth_cookie>` stores the credentials encrypted.
+- `dsmon opencode-go` prints OpenCode Go quota; `dsmon opencode-go set <workspace_id> <auth_cookie>` stores the credentials encrypted; `dsmon opencode-go json` emits machine-readable output.
+- The Plasma 6 widget adds a dedicated "OpenCode Go" settings page, read directly from `dsmon opencode-go json`.
 - Plasma 6 widget: transparent liquid-glass desktop view with balance, last check, API service status, estimated availability, refresh control, and emoji status text.
 - Plasma 6 widget display is intentionally compact: the main desktop view shows a balance line, relative last-check time, DeepSeek API status, and estimated remaining time.
 - Refreshing the Linux Plasma widget model: balance, relative last check, API service status, and estimated availability now match the Rainmeter widget layout.

--- a/README_zh.md
+++ b/README_zh.md
@@ -28,9 +28,11 @@ Rainmeter 小组件预览图
 - Demo 模式无需真实 Key 即可测试：Py-Win/Py-Mac 提供开发者面板，Rust 通过保存 `demo` 作为 API Key 触发。
 - API Key 加密存储：Py-Win 使用 Fernet + SQLite，Rust 使用 SQLite `secure_settings`，Py-Mac 使用 Keychain。
 - Rainmeter 桌面小工具：仅本地可访问的状态接口；`.rmskin` 发布打包。Rust/Python Windows 双版均已支持。
+- OpenCode Go 额度显示（Rust 版）：爬取 opencode.ai 工作区仪表板，展示 5 小时滚动 / 每周 / 每月三档用量；凭据加密存于 SQLite，绝不写入 config.json。
 
 Rust Linux 版本限定：
 - Rust Linux：`dsmon set-key` 和 `dsmon set <field> <value>`；daemon 每轮轮询重新读取配置；CLI 固定英文输出。
+- `dsmon opencode-go` 输出 OpenCode Go 额度；`dsmon opencode-go set <workspace_id> <auth_cookie>` 加密保存凭据。
 - Plasma 6 小组件：透明液态玻璃桌面样式，余额、上次查询、服务状态、预计可用时间、刷新按钮和 emoji 状态。
 - Plasma 6 小组件显示刻意保持紧凑：桌面主视图显示余额行、相对上次查询时间、DeepSeek API 状态和预计剩余时间。
 - 刷新 Linux Plasma 小组件显示模型：余额、相对上次查询、API 服务状态和预计可用时间现在与 Rainmeter 小工具布局一致。
@@ -45,6 +47,7 @@ Rust Linux 版本限定：
 - **余额详情** — 左键单击图标查看余额（emoji 前缀）、消耗速率、API 服务状态和相对时间
 - **历史记录页** — 分页表格展示所有余额记录，附带折线图和消耗分析，支持 CSV 导出
 - **设置** — API Key（Fernet + SQLite加密存储）、查询间隔、预警阈值、提醒模式、图标主题、代理等
+- **OpenCode Go 额度**（Rust 版）— Windows 设置标签页或 Linux `dsmon opencode-go` 展示 opencode.ai 仪表板的 5h/每周/每月用量，凭据加密存储
 - **Demo 模式** — `--demo` 免 Key 体验，开发者面板可调参数
 - **可选桌面小工具** — Linux 支持 KDE Plasma 6，Windows 支持 Rainmeter（Rust/Python 双版均已适配）
 - **社区移植** — Rust-Win（Win7+）、Rust-Linux（CLI + Plasma 6 小组件）、Py-Mac（Keychain 加密，WebView 设置界面）
@@ -177,6 +180,7 @@ CLI 目前仅 Rust Linux 版提供。Windows 和 MacOS 版使用图形界面 / �
 | `dsmon history [days]` | 输出余额历史统计摘要 |
 | `dsmon history export [days] [currency\|all] [path\|-]` | 导出历史 CSV；`-` 表示输出到 stdout |
 | `dsmon widget-status` | 输出 Plasma 小组件读取的 JSON 状态 |
+| `dsmon opencode-go` | 输出 OpenCode Go 额度（5h/每周/每月用量）；凭据用 `dsmon opencode-go set <workspace_id> <auth_cookie>` 设置 |
 
 **MacOS（`src/mac/`）：**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,7 +32,8 @@ Rainmeter 小组件预览图
 
 Rust Linux 版本限定：
 - Rust Linux：`dsmon set-key` 和 `dsmon set <field> <value>`；daemon 每轮轮询重新读取配置；CLI 固定英文输出。
-- `dsmon opencode-go` 输出 OpenCode Go 额度；`dsmon opencode-go set <workspace_id> <auth_cookie>` 加密保存凭据。
+- `dsmon opencode-go` 输出 OpenCode Go 额度；`dsmon opencode-go set <workspace_id> <auth_cookie>` 加密保存凭据；`dsmon opencode-go json` 输出机器可读 JSON。
+- Plasma 6 小组件新增独立的「OpenCode Go」设置页面，直接从 `dsmon opencode-go json` 读取。
 - Plasma 6 小组件：透明液态玻璃桌面样式，余额、上次查询、服务状态、预计可用时间、刷新按钮和 emoji 状态。
 - Plasma 6 小组件显示刻意保持紧凑：桌面主视图显示余额行、相对上次查询时间、DeepSeek API 状态和预计剩余时间。
 - 刷新 Linux Plasma 小组件显示模型：余额、相对上次查询、API 服务状态和预计可用时间现在与 Rainmeter 小工具布局一致。

--- a/README_zh.md
+++ b/README_zh.md
@@ -32,7 +32,7 @@ Rainmeter 小组件预览图
 
 Rust Linux 版本限定：
 - Rust Linux：`dsmon set-key` 和 `dsmon set <field> <value>`；daemon 每轮轮询重新读取配置；CLI 固定英文输出。
-- `dsmon opencode-go` 输出 OpenCode Go 额度；`dsmon opencode-go set <workspace_id> <auth_cookie>` 加密保存凭据；`dsmon opencode-go json` 输出机器可读 JSON。
+- `dsmon opencode-go` 输出 OpenCode Go 额度；`dsmon opencode-go set "workspace_id" "auth_cookie"` 加密保存凭据（两个参数均需用半角双引号包裹，auth cookie 含特殊字符）；`dsmon opencode-go json` 输出机器可读 JSON。
 - Plasma 6 小组件新增独立的「OpenCode Go」设置页面，直接从 `dsmon opencode-go json` 读取。
 - Plasma 6 小组件：透明液态玻璃桌面样式，余额、上次查询、服务状态、预计可用时间、刷新按钮和 emoji 状态。
 - Plasma 6 小组件显示刻意保持紧凑：桌面主视图显示余额行、相对上次查询时间、DeepSeek API 状态和预计剩余时间。
@@ -181,7 +181,7 @@ CLI 目前仅 Rust Linux 版提供。Windows 和 MacOS 版使用图形界面 / �
 | `dsmon history [days]` | 输出余额历史统计摘要 |
 | `dsmon history export [days] [currency\|all] [path\|-]` | 导出历史 CSV；`-` 表示输出到 stdout |
 | `dsmon widget-status` | 输出 Plasma 小组件读取的 JSON 状态 |
-| `dsmon opencode-go` | 输出 OpenCode Go 额度（5h/每周/每月用量）；凭据用 `dsmon opencode-go set <workspace_id> <auth_cookie>` 设置 |
+| `dsmon opencode-go` | 输出 OpenCode Go 额度（5h/每周/每月用量）；凭据用 `dsmon opencode-go set "workspace_id" "auth_cookie"` 设置，两个参数都要用半角双引号包裹（auth cookie 含特殊字符） |
 
 **MacOS（`src/mac/`）：**
 

--- a/rust-linux/Cargo.lock
+++ b/rust-linux/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "dsmon"
-version = "1.2.6"
+version = "1.2.10"
 dependencies = [
  "chrono",
  "indexmap",

--- a/rust-linux/Cargo.toml
+++ b/rust-linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsmon"
-version = "1.2.6"
+version = "1.2.10"
 edition = "2021"
 rust-version = "1.77.2"
 description = "Linux CLI usage monitor for the DeepSeek API"

--- a/rust-linux/plasmoid/package/contents/config/config.qml
+++ b/rust-linux/plasmoid/package/contents/config/config.qml
@@ -10,8 +10,8 @@ ConfigModel {
     }
 
     function tr(key) {
-        var zh = { general: "常规", history: "历史" }
-        var en = { general: "General", history: "History" }
+        var zh = { general: "常规", history: "历史", opencodeGo: "OpenCode Go" }
+        var en = { general: "General", history: "History", opencodeGo: "OpenCode Go" }
         var table = systemLanguage() === "zh" ? zh : en
         return table[key] || key
     }
@@ -25,5 +25,10 @@ ConfigModel {
         name: tr("history")
         icon: "view-history"
         source: "configHistory.qml"
+    }
+    ConfigCategory {
+        name: tr("opencodeGo")
+        icon: "network-server"
+        source: "configOpencodeGo.qml"
     }
 }

--- a/rust-linux/plasmoid/package/contents/ui/configOpencodeGo.qml
+++ b/rust-linux/plasmoid/package/contents/ui/configOpencodeGo.qml
@@ -1,0 +1,179 @@
+import QtQuick
+import QtQuick.Controls as QtControls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import org.kde.kcmutils as KCM
+import org.kde.plasma.plasma5support as Plasma5Support
+
+KCM.SimpleKCM {
+    id: page
+
+    property bool busy: false
+    property string statusText: ""
+    property string opencodeGoText: ""
+    property string pageLanguage: systemLanguage()
+    property string cfg_language: pageLanguage
+    property string cfg_languageDefault: systemLanguage()
+    property bool cfg_expanding: false
+    property int cfg_length: 0
+    readonly property string uiLanguage: pageLanguage
+
+    function systemLanguage() {
+        var localeName = Qt.locale().name
+        if (!localeName || String(localeName).length === 0) {
+            return "zh"
+        }
+        return String(localeName).indexOf("zh") === 0 ? "zh" : "en"
+    }
+
+    function tr(key) {
+        var zh = {
+            opencodeGoTitle: "OpenCode Go 额度",
+            ogNotConfigured: "未配置 OpenCode Go 凭据。请在终端运行 dsmon opencode-go set <workspace_id> <auth_cookie> 进行配置。",
+            ogChecking: "查询 OpenCode Go 额度中...",
+            ogError: "OpenCode Go 额度查询失败：",
+            og5h: "5h",
+            ogWeekly: "每周",
+            ogMonthly: "每月",
+            ogUnavailable: "不可用",
+            loading: "正在加载...",
+            loaded: "已加载。",
+            loadFailed: "加载失败：",
+            refresh: "刷新"
+        }
+        var en = {
+            opencodeGoTitle: "OpenCode Go Quota",
+            ogNotConfigured: "OpenCode Go credentials are not configured. Run dsmon opencode-go set <workspace_id> <auth_cookie> in a terminal.",
+            ogChecking: "Checking OpenCode Go quota...",
+            ogError: "Failed to fetch OpenCode Go quota: ",
+            og5h: "5h",
+            ogWeekly: "Weekly",
+            ogMonthly: "Monthly",
+            ogUnavailable: "unavailable",
+            loading: "Loading...",
+            loaded: "Loaded.",
+            loadFailed: "Failed to load: ",
+            refresh: "Refresh"
+        }
+        var table = uiLanguage === "zh" ? zh : en
+        return table[key] || key
+    }
+
+    function formatOgWindow(label, usage) {
+        if (!usage) {
+            return label + ": " + tr("ogUnavailable")
+        }
+        return label + ": " + Math.round(usage.usage_percent) + "% used | "
+            + Math.round(usage.percent_remaining) + "% remaining | resets in "
+            + formatResetSeconds(usage.reset_in_sec)
+    }
+
+    function formatResetSeconds(secs) {
+        if (secs <= 0) {
+            return "now"
+        }
+        var days = Math.floor(secs / 86400)
+        var hours = Math.floor((secs % 86400) / 3600)
+        var minutes = Math.floor((secs % 3600) / 60)
+        var parts = []
+        if (days > 0) {
+            parts.push(days + "d")
+        }
+        if (hours > 0) {
+            parts.push(hours + "h")
+        }
+        if (minutes > 0) {
+            parts.push(minutes + "m")
+        }
+        if (parts.length === 0) {
+            parts.push((secs % 60) + "s")
+        }
+        return parts.join(" ")
+    }
+
+    function loadConfig() {
+        busy = true
+        statusText = tr("loading")
+        loader.connectSource("/usr/local/bin/dsmon config-json")
+    }
+
+    function loadOpencodeGo() {
+        busy = true
+        statusText = tr("loading")
+        opencodeGoText = tr("ogChecking")
+        loader.connectSource("/usr/local/bin/dsmon opencode-go json")
+    }
+
+    function refresh() {
+        loadOpencodeGo()
+    }
+
+    Component.onCompleted: loadConfig()
+
+    Plasma5Support.DataSource {
+        id: loader
+        engine: "executable"
+        connectedSources: []
+        onNewData: function(sourceName, data) {
+            var stdout = data["stdout"] || ""
+            var stderr = data["stderr"] || ""
+            if (String(sourceName).indexOf("config-json") !== -1) {
+                try {
+                    var config = JSON.parse(stdout)
+                    pageLanguage = config.ui_language === "zh" || config.ui_language === "en"
+                        ? config.ui_language
+                        : systemLanguage()
+                } catch (error) {
+                    pageLanguage = systemLanguage()
+                }
+                disconnectSource(sourceName)
+                loadOpencodeGo()
+                return
+            }
+            busy = false
+            if (stderr.trim().length > 0 && stdout.trim().length === 0) {
+                statusText = tr("ogError") + stderr.trim()
+            } else {
+                try {
+                    var status = JSON.parse(stdout)
+                    if (!status.configured) {
+                        opencodeGoText = tr("ogNotConfigured")
+                    } else if (status.error && status.error.length > 0) {
+                        opencodeGoText = tr("ogError") + status.error
+                    } else {
+                        var lines = [tr("opencodeGoTitle")]
+                        lines.push(formatOgWindow(tr("og5h"), status.rolling))
+                        lines.push(formatOgWindow(tr("ogWeekly"), status.weekly))
+                        lines.push(formatOgWindow(tr("ogMonthly"), status.monthly))
+                        opencodeGoText = lines.join("\n")
+                    }
+                    statusText = tr("loaded")
+                } catch (error) {
+                    opencodeGoText = tr("ogError") + error
+                    statusText = tr("loadFailed") + error
+                }
+            }
+            disconnectSource(sourceName)
+        }
+    }
+
+    Kirigami.FormLayout {
+        QtControls.Button {
+            text: tr("refresh")
+            enabled: !busy
+            onClicked: refresh()
+        }
+
+        QtControls.Label {
+            Layout.fillWidth: true
+            text: opencodeGoText
+            wrapMode: Text.WordWrap
+        }
+
+        QtControls.Label {
+            Layout.fillWidth: true
+            text: statusText
+            wrapMode: Text.WordWrap
+        }
+    }
+}

--- a/rust-linux/plasmoid/package/contents/ui/configOpencodeGo.qml
+++ b/rust-linux/plasmoid/package/contents/ui/configOpencodeGo.qml
@@ -11,6 +11,12 @@ KCM.SimpleKCM {
     property bool busy: false
     property string statusText: ""
     property string opencodeGoText: ""
+    property real rollingPercent: 0
+    property real weeklyPercent: 0
+    property real monthlyPercent: 0
+    property string rollingText: "--"
+    property string weeklyText: "--"
+    property string monthlyText: "--"
     property string pageLanguage: systemLanguage()
     property string cfg_language: pageLanguage
     property string cfg_languageDefault: systemLanguage()
@@ -59,13 +65,21 @@ KCM.SimpleKCM {
         return table[key] || key
     }
 
-    function formatOgWindow(label, usage) {
-        if (!usage) {
-            return label + ": " + tr("ogUnavailable")
+    function barColor(percent) {
+        if (percent >= 80) {
+            return "#e53935"
         }
-        return label + ": " + Math.round(usage.usage_percent) + "% used | "
-            + Math.round(usage.percent_remaining) + "% remaining | resets in "
-            + formatResetSeconds(usage.reset_in_sec)
+        if (percent >= 60) {
+            return "#ffb300"
+        }
+        return "#4caf50"
+    }
+
+    function formatOgValue(usage) {
+        if (!usage) {
+            return tr("ogUnavailable")
+        }
+        return Math.round(usage.usage_percent) + "% · " + formatResetSeconds(usage.reset_in_sec)
     }
 
     function formatResetSeconds(secs) {
@@ -101,6 +115,12 @@ KCM.SimpleKCM {
         busy = true
         statusText = tr("loading")
         opencodeGoText = tr("ogChecking")
+        rollingPercent = 0
+        weeklyPercent = 0
+        monthlyPercent = 0
+        rollingText = "--"
+        weeklyText = "--"
+        monthlyText = "--"
         loader.connectSource("/usr/local/bin/dsmon opencode-go json")
     }
 
@@ -141,11 +161,13 @@ KCM.SimpleKCM {
                     } else if (status.error && status.error.length > 0) {
                         opencodeGoText = tr("ogError") + status.error
                     } else {
-                        var lines = [tr("opencodeGoTitle")]
-                        lines.push(formatOgWindow(tr("og5h"), status.rolling))
-                        lines.push(formatOgWindow(tr("ogWeekly"), status.weekly))
-                        lines.push(formatOgWindow(tr("ogMonthly"), status.monthly))
-                        opencodeGoText = lines.join("\n")
+                        rollingPercent = status.rolling ? status.rolling.usage_percent : 0
+                        weeklyPercent = status.weekly ? status.weekly.usage_percent : 0
+                        monthlyPercent = status.monthly ? status.monthly.usage_percent : 0
+                        rollingText = formatOgValue(status.rolling)
+                        weeklyText = formatOgValue(status.weekly)
+                        monthlyText = formatOgValue(status.monthly)
+                        opencodeGoText = tr("opencodeGoTitle")
                     }
                     statusText = tr("loaded")
                 } catch (error) {
@@ -162,6 +184,99 @@ KCM.SimpleKCM {
             text: tr("refresh")
             enabled: !busy
             onClicked: refresh()
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            QtControls.Label {
+                text: tr("og5h")
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+            }
+            Rectangle {
+                id: rollingTrack
+                Layout.fillWidth: true
+                Layout.preferredHeight: 12
+                radius: 6
+                color: Kirigami.Theme.backgroundColor
+                border.color: Kirigami.Theme.disabledTextColor
+                border.width: 1
+                Rectangle {
+                    id: rollingFill
+                    width: parent.width * Math.min(1, page.rollingPercent / 100)
+                    height: parent.height
+                    radius: 6
+                    color: page.barColor(page.rollingPercent)
+                }
+            }
+            QtControls.Label {
+                text: page.rollingText
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 7
+                horizontalAlignment: Text.AlignRight
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            QtControls.Label {
+                text: tr("ogWeekly")
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+            }
+            Rectangle {
+                id: weeklyTrack
+                Layout.fillWidth: true
+                Layout.preferredHeight: 12
+                radius: 6
+                color: Kirigami.Theme.backgroundColor
+                border.color: Kirigami.Theme.disabledTextColor
+                border.width: 1
+                Rectangle {
+                    id: weeklyFill
+                    width: parent.width * Math.min(1, page.weeklyPercent / 100)
+                    height: parent.height
+                    radius: 6
+                    color: page.barColor(page.weeklyPercent)
+                }
+            }
+            QtControls.Label {
+                text: page.weeklyText
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 7
+                horizontalAlignment: Text.AlignRight
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            QtControls.Label {
+                text: tr("ogMonthly")
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 4
+            }
+            Rectangle {
+                id: monthlyTrack
+                Layout.fillWidth: true
+                Layout.preferredHeight: 12
+                radius: 6
+                color: Kirigami.Theme.backgroundColor
+                border.color: Kirigami.Theme.disabledTextColor
+                border.width: 1
+                Rectangle {
+                    id: monthlyFill
+                    width: parent.width * Math.min(1, page.monthlyPercent / 100)
+                    height: parent.height
+                    radius: 6
+                    color: page.barColor(page.monthlyPercent)
+                }
+            }
+            QtControls.Label {
+                text: page.monthlyText
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 7
+                horizontalAlignment: Text.AlignRight
+            }
         }
 
         QtControls.Label {

--- a/rust-linux/plasmoid/package/metadata.json
+++ b/rust-linux/plasmoid/package/metadata.json
@@ -12,7 +12,7 @@
     "Id": "com.github.wenyinos.deepseek-balance-monitor",
     "License": "MIT",
     "Name": "DeepSeek Balance Monitor",
-    "Version": "1.2.5",
+    "Version": "1.2.10",
     "Website": "https://github.com/wenyinos/DeepSeekBalanceMonitor"
   },
   "X-Plasma-API-Minimum-Version": "6.0"

--- a/rust-linux/src/main.rs
+++ b/rust-linux/src/main.rs
@@ -403,7 +403,7 @@ fn clean_logs() -> Result<(), (i32, String)> {
 
 fn print_help() {
     println!(
-        "Usage: dsmon [check|daemon|init-config|config-path|log-path|clean-logs|history|widget-status|config-json|set-key|set|set-config|opencode-go]\nHistory: dsmon history [days] | dsmon history export [days] [currency|all] [path|-]\nSet: dsmon set <field> <value>\nOpenCode Go: dsmon opencode-go | dsmon opencode-go set <workspace_id> <auth_cookie>"
+        "Usage: dsmon [check|daemon|init-config|config-path|log-path|clean-logs|history|widget-status|config-json|set-key|set|set-config|opencode-go]\nHistory: dsmon history [days] | dsmon history export [days] [currency|all] [path|-]\nSet: dsmon set <field> <value>\nOpenCode Go: dsmon opencode-go | dsmon opencode-go set <workspace_id> <auth_cookie> | dsmon opencode-go json"
     );
 }
 
@@ -1251,6 +1251,7 @@ fn set_config(args: &[String]) -> Result<(), (i32, String)> {
 fn opencode_go(args: &[String]) -> Result<(), (i32, String)> {
     match args.first().map(String::as_str) {
         Some("set") | Some("set-key") => opencode_go_set(&args[1..]),
+        Some("json") => opencode_go_json(),
         Some(other) => Err(fail(format!(
             "Unknown opencode-go subcommand: {other}\nRun: dsmon opencode-go set <workspace_id> <auth_cookie>"
         ))),
@@ -1297,6 +1298,41 @@ fn opencode_go_check() -> Result<(), (i32, String)> {
         }
         Err(error) => Err((1, error)),
     }
+}
+
+fn opencode_go_json() -> Result<(), (i32, String)> {
+    let config = load_config().map_err(fail)?;
+    let workspace_id = read_secure_value(OPENCODE_GO_WORKSPACE_KEY)
+        .map_err(fail)?
+        .unwrap_or_default();
+    let auth_cookie = read_secure_value(OPENCODE_GO_AUTH_COOKIE_KEY)
+        .map_err(fail)?
+        .unwrap_or_default();
+    let payload = if workspace_id.is_empty() || auth_cookie.is_empty() {
+        serde_json::json!({
+            "configured": false,
+            "error": "OpenCode Go credentials are not configured.\nRun: dsmon opencode-go set <workspace_id> <auth_cookie>"
+        })
+    } else {
+        match fetch_opencode_go_quota(&workspace_id, &auth_cookie, effective_http_proxy(&config)) {
+            Ok(quota) => serde_json::json!({
+                "configured": true,
+                "error": null,
+                "rolling": quota.rolling,
+                "weekly": quota.weekly,
+                "monthly": quota.monthly
+            }),
+            Err(error) => serde_json::json!({
+                "configured": true,
+                "error": error,
+                "rolling": null,
+                "weekly": null,
+                "monthly": null
+            }),
+        }
+    };
+    println!("{payload}");
+    Ok(())
 }
 
 fn print_opencode_go_quota(quota: &OpenCodeGoQuota) {
@@ -2563,6 +2599,14 @@ mod tests {
         assert!(config_qml.contains("config.export_path"));
         assert!(config_qml.contains("/usr/local/bin/dsmon set "));
         assert!(!config_qml.contains("set-config"));
+        let opencode_go_qml = include_str!("../plasmoid/package/contents/ui/configOpencodeGo.qml");
+        assert!(opencode_go_qml.contains("/usr/local/bin/dsmon opencode-go json"));
+        assert!(opencode_go_qml.contains("opencodeGoTitle"));
+        assert!(opencode_go_qml.contains("formatOgWindow"));
+        assert!(opencode_go_qml.contains("ogNotConfigured"));
+        let config_model = include_str!("../plasmoid/package/contents/config/config.qml");
+        assert!(config_model.contains("configOpencodeGo.qml"));
+        assert!(config_model.contains("opencodeGo"));
     }
 
     #[test]

--- a/rust-linux/src/main.rs
+++ b/rust-linux/src/main.rs
@@ -2602,7 +2602,9 @@ mod tests {
         let opencode_go_qml = include_str!("../plasmoid/package/contents/ui/configOpencodeGo.qml");
         assert!(opencode_go_qml.contains("/usr/local/bin/dsmon opencode-go json"));
         assert!(opencode_go_qml.contains("opencodeGoTitle"));
-        assert!(opencode_go_qml.contains("formatOgWindow"));
+        assert!(opencode_go_qml.contains("barColor"));
+        assert!(opencode_go_qml.contains("rollingPercent"));
+        assert!(opencode_go_qml.contains("formatOgValue"));
         assert!(opencode_go_qml.contains("ogNotConfigured"));
         let config_model = include_str!("../plasmoid/package/contents/config/config.qml");
         assert!(config_model.contains("configOpencodeGo.qml"));

--- a/rust-linux/src/main.rs
+++ b/rust-linux/src/main.rs
@@ -21,6 +21,12 @@ const SECURE_PREFIX: &[u8] = b"DSBM1";
 const SECURE_AAD: &[u8] = b"deepseek-balance-monitor secure_settings api_key v1";
 const NONCE_LEN: usize = 12;
 const API_KEY_MASK: &str = "masked";
+const OPENCODE_GO_URL_PREFIX: &str = "https://opencode.ai/workspace/";
+const OPENCODE_GO_URL_SUFFIX: &str = "/go";
+const OPENCODE_GO_USER_AGENT: &str =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/20100101 Firefox/148.0";
+const OPENCODE_GO_WORKSPACE_KEY: &str = "opencode_go_workspace_id";
+const OPENCODE_GO_AUTH_COOKIE_KEY: &str = "opencode_go_auth_cookie";
 
 #[derive(Clone, Serialize, Deserialize)]
 struct AppConfig {
@@ -131,6 +137,20 @@ struct ConsumptionRate {
     currency: String,
 }
 
+#[derive(Clone, Debug, Serialize)]
+struct OpenCodeGoUsage {
+    usage_percent: f64,
+    percent_remaining: f64,
+    reset_in_sec: i64,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct OpenCodeGoQuota {
+    rolling: Option<OpenCodeGoUsage>,
+    weekly: Option<OpenCodeGoUsage>,
+    monthly: Option<OpenCodeGoUsage>,
+}
+
 #[derive(Serialize)]
 struct WidgetStatus {
     ok: bool,
@@ -210,6 +230,7 @@ fn run() -> Result<(), (i32, String)> {
         "set-key" => set_key(&args[2..]),
         "set" => set_config_field(&args[2..]),
         "set-config" => set_config(&args[2..]),
+        "opencode-go" => opencode_go(&args[2..]),
         "-V" | "--version" => {
             println!("dsmon {}", env!("CARGO_PKG_VERSION"));
             Ok(())
@@ -382,7 +403,7 @@ fn clean_logs() -> Result<(), (i32, String)> {
 
 fn print_help() {
     println!(
-        "Usage: dsmon [check|daemon|init-config|config-path|log-path|clean-logs|history|widget-status|config-json|set-key|set|set-config]\nHistory: dsmon history [days] | dsmon history export [days] [currency|all] [path|-]\nSet: dsmon set <field> <value>"
+        "Usage: dsmon [check|daemon|init-config|config-path|log-path|clean-logs|history|widget-status|config-json|set-key|set|set-config|opencode-go]\nHistory: dsmon history [days] | dsmon history export [days] [currency|all] [path|-]\nSet: dsmon set <field> <value>\nOpenCode Go: dsmon opencode-go | dsmon opencode-go set <workspace_id> <auth_cookie>"
     );
 }
 
@@ -1227,6 +1248,323 @@ fn set_config(args: &[String]) -> Result<(), (i32, String)> {
     Ok(())
 }
 
+fn opencode_go(args: &[String]) -> Result<(), (i32, String)> {
+    match args.first().map(String::as_str) {
+        Some("set") | Some("set-key") => opencode_go_set(&args[1..]),
+        Some(other) => Err(fail(format!(
+            "Unknown opencode-go subcommand: {other}\nRun: dsmon opencode-go set <workspace_id> <auth_cookie>"
+        ))),
+        None => opencode_go_check(),
+    }
+}
+
+fn opencode_go_set(args: &[String]) -> Result<(), (i32, String)> {
+    if args.len() < 2 {
+        return Err(fail(
+            "Usage: dsmon opencode-go set <workspace_id> <auth_cookie>",
+        ));
+    }
+    let workspace_id = args[0].trim();
+    let auth_cookie = args[1].trim();
+    if workspace_id.is_empty() || auth_cookie.is_empty() {
+        return Err(fail("workspace_id and auth_cookie are required."));
+    }
+    store_secure_value(OPENCODE_GO_WORKSPACE_KEY, workspace_id).map_err(fail)?;
+    store_secure_value(OPENCODE_GO_AUTH_COOKIE_KEY, auth_cookie).map_err(fail)?;
+    println!("OpenCode Go credentials saved.");
+    Ok(())
+}
+
+fn opencode_go_check() -> Result<(), (i32, String)> {
+    let config = load_config().map_err(fail)?;
+    let workspace_id = read_secure_value(OPENCODE_GO_WORKSPACE_KEY)
+        .map_err(fail)?
+        .unwrap_or_default();
+    let auth_cookie = read_secure_value(OPENCODE_GO_AUTH_COOKIE_KEY)
+        .map_err(fail)?
+        .unwrap_or_default();
+    if workspace_id.is_empty() || auth_cookie.is_empty() {
+        return Err((
+            2,
+            "OpenCode Go credentials are not configured.\nRun: dsmon opencode-go set <workspace_id> <auth_cookie>"
+                .to_string(),
+        ));
+    }
+    match fetch_opencode_go_quota(&workspace_id, &auth_cookie, effective_http_proxy(&config)) {
+        Ok(quota) => {
+            print_opencode_go_quota(&quota);
+            Ok(())
+        }
+        Err(error) => Err((1, error)),
+    }
+}
+
+fn print_opencode_go_quota(quota: &OpenCodeGoQuota) {
+    println!("OpenCode Go:");
+    print_opencode_go_window("5h", quota.rolling.as_ref());
+    print_opencode_go_window("Weekly", quota.weekly.as_ref());
+    print_opencode_go_window("Monthly", quota.monthly.as_ref());
+}
+
+fn print_opencode_go_window(label: &str, usage: Option<&OpenCodeGoUsage>) {
+    match usage {
+        Some(usage) => println!(
+            "  {label:<8} {:.0}% used | {:.0}% remaining | resets in {}",
+            usage.usage_percent,
+            usage.percent_remaining,
+            format_reset_seconds(usage.reset_in_sec)
+        ),
+        None => println!("  {label:<8} (unavailable)"),
+    }
+}
+
+fn fetch_opencode_go_quota(
+    workspace_id: &str,
+    auth_cookie: &str,
+    http_proxy: &str,
+) -> Result<OpenCodeGoQuota, String> {
+    let client = http_client(Duration::from_secs(10), http_proxy)?;
+    let url = format!(
+        "{}{}{}",
+        OPENCODE_GO_URL_PREFIX,
+        encode_uri_component(workspace_id),
+        OPENCODE_GO_URL_SUFFIX
+    );
+    let response = client
+        .get(&url)
+        .header("Accept", "text/html")
+        .header("User-Agent", OPENCODE_GO_USER_AGENT)
+        .header("Cookie", format!("auth={auth_cookie}"))
+        .send()
+        .map_err(|e| format!("OpenCode Go request failed: {e}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().unwrap_or_default();
+        return Err(format!(
+            "OpenCode Go dashboard error {status}: {}",
+            sanitize_opencode_go_message(&text)
+        ));
+    }
+    let html = response
+        .text()
+        .map_err(|e| format!("OpenCode Go HTML read failed: {e}"))?;
+    parse_opencode_go_quota(&html)
+}
+
+fn parse_opencode_go_quota(html: &str) -> Result<OpenCodeGoQuota, String> {
+    let ssr = OpenCodeGoQuota {
+        rolling: parse_ssr_window(html, "rollingUsage"),
+        weekly: parse_ssr_window(html, "weeklyUsage"),
+        monthly: parse_ssr_window(html, "monthlyUsage"),
+    };
+    let any = ssr.rolling.is_some() || ssr.weekly.is_some() || ssr.monthly.is_some();
+    let quota = if any {
+        ssr
+    } else {
+        parse_opencode_go_data_slot(html)
+    };
+    if quota.rolling.is_none() && quota.weekly.is_none() && quota.monthly.is_none() {
+        return Err(
+            "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)"
+                .to_string(),
+        );
+    }
+    Ok(quota)
+}
+
+fn parse_ssr_window(html: &str, window: &str) -> Option<OpenCodeGoUsage> {
+    let marker = format!("{window}:$R[");
+    let start = html.find(&marker)?;
+    let rest = &html[start + marker.len()..];
+    let open = rest.find('{')? + 1;
+    let content_end = rest[open..].find('}')?;
+    let content = &rest[open..open + content_end];
+    let usage_percent = number_after_key(content, "usagePercent")?.max(0.0);
+    let reset_in_sec = number_after_key(content, "resetInSec")?.max(0.0);
+    Some(OpenCodeGoUsage {
+        usage_percent,
+        percent_remaining: (100.0 - usage_percent).max(0.0),
+        reset_in_sec: reset_in_sec as i64,
+    })
+}
+
+fn parse_opencode_go_data_slot(html: &str) -> OpenCodeGoQuota {
+    let mut quota = OpenCodeGoQuota::default();
+    for item in html.split("data-slot=\"usage-item\"").skip(1) {
+        let Some(label) = tag_text(item, "data-slot=\"usage-label\"") else {
+            continue;
+        };
+        let Some(usage_text) = tag_text(item, "data-slot=\"usage-value\"") else {
+            continue;
+        };
+        let Some(usage_percent) = first_number(&usage_text) else {
+            continue;
+        };
+        let reset_in_sec = if item.contains("data-slot=\"reset-now\"") {
+            0
+        } else {
+            let Some(reset_text) = tag_text(item, "data-slot=\"reset-time\"") else {
+                continue;
+            };
+            match parse_human_readable_time(&reset_text) {
+                Some(secs) => secs,
+                None => continue,
+            }
+        };
+        let window_key = if label.to_lowercase().contains("rolling") {
+            Some("rolling")
+        } else if label.to_lowercase().contains("weekly") {
+            Some("weekly")
+        } else if label.to_lowercase().contains("monthly") {
+            Some("monthly")
+        } else {
+            None
+        };
+        let Some(window_key) = window_key else {
+            continue;
+        };
+        let usage = OpenCodeGoUsage {
+            usage_percent,
+            percent_remaining: (100.0 - usage_percent).max(0.0),
+            reset_in_sec,
+        };
+        match window_key {
+            "rolling" => quota.rolling = Some(usage),
+            "weekly" => quota.weekly = Some(usage),
+            _ => quota.monthly = Some(usage),
+        }
+    }
+    quota
+}
+
+fn tag_text<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
+    let start = text.find(marker)? + marker.len();
+    let rest = &text[start..];
+    let open = rest.find('>')? + 1;
+    let content = &rest[open..];
+    let end = content.find('<')?;
+    Some(content[..end].trim())
+}
+
+fn number_after_key(text: &str, key: &str) -> Option<f64> {
+    let rest = &text[text.find(key)? + key.len()..];
+    let rest = rest.strip_prefix(':')?;
+    let number: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-' || *c == '+')
+        .collect();
+    if number.is_empty() {
+        return None;
+    }
+    number.parse().ok()
+}
+
+fn first_number(text: &str) -> Option<f64> {
+    let start = text.find(|c: char| c.is_ascii_digit())?;
+    let rest = &text[start..];
+    let number: String = rest
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    if number.is_empty() {
+        return None;
+    }
+    number.parse().ok()
+}
+
+fn parse_human_readable_time(text: &str) -> Option<i64> {
+    let normalized = text.to_lowercase();
+    if normalized.contains("reset now")
+        || normalized.contains("resets now")
+        || normalized.trim() == "now"
+    {
+        return Some(0);
+    }
+    let mut total: i64 = 0;
+    let mut found = false;
+    for (plural, singular, multiplier) in [
+        ("days", "day", 86400i64),
+        ("hours", "hour", 3600),
+        ("minutes", "minute", 60),
+        ("seconds", "second", 1),
+    ] {
+        let unit = if normalized.contains(plural) {
+            plural
+        } else {
+            singular
+        };
+        if let Some(prefix) = number_before_word(&normalized, unit) {
+            if let Ok(n) = prefix.parse::<f64>() {
+                total += (n * multiplier as f64) as i64;
+                found = true;
+            }
+        }
+    }
+    found.then_some(total)
+}
+
+fn number_before_word<'a>(text: &'a str, word: &str) -> Option<&'a str> {
+    let index = text.find(word)?;
+    let before = text[..index].trim_end();
+    if before.is_empty() {
+        return None;
+    }
+    let start = before
+        .rfind(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let candidate = &before[start..];
+    if candidate.is_empty() || !candidate.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(candidate)
+}
+
+fn format_reset_seconds(secs: i64) -> String {
+    if secs <= 0 {
+        return "now".to_string();
+    }
+    let days = secs / 86400;
+    let hours = (secs % 86400) / 3600;
+    let minutes = (secs % 3600) / 60;
+    let mut parts = Vec::new();
+    if days > 0 {
+        parts.push(format!("{days}d"));
+    }
+    if hours > 0 {
+        parts.push(format!("{hours}h"));
+    }
+    if minutes > 0 {
+        parts.push(format!("{minutes}m"));
+    }
+    if parts.is_empty() {
+        parts.push(format!("{}s", secs % 60));
+    }
+    parts.join(" ")
+}
+
+fn encode_uri_component(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push_str(&format!("{byte:02X}"));
+        }
+    }
+    out
+}
+
+fn sanitize_opencode_go_message(text: &str) -> String {
+    let cleaned: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if cleaned.is_empty() {
+        "unknown".to_string()
+    } else {
+        cleaned.chars().take(120).collect()
+    }
+}
+
 fn fetch_balance(api_key: &str, http_proxy: &str) -> Result<BTreeMap<String, Balance>, String> {
     let client = http_client(Duration::from_secs(15), http_proxy)?;
     let response = client
@@ -1640,6 +1978,32 @@ fn store_secure_api_key(api_key: &str) -> Result<(), String> {
     conn.execute(
         "INSERT OR REPLACE INTO secure_settings (key, value, updated_at) VALUES (?1, ?2, ?3)",
         params!["api_key", encrypted, format_time(Local::now())],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn read_secure_value(key: &str) -> Result<Option<String>, String> {
+    let conn = open_history_db()?;
+    let encrypted = match conn.query_row(
+        "SELECT value FROM secure_settings WHERE key = ?1",
+        params![key],
+        |row| row.get::<_, Vec<u8>>(0),
+    ) {
+        Ok(value) => value,
+        Err(SqlError::QueryReturnedNoRows) => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    let value = decrypt_secret(&encrypted)?;
+    Ok((!value.trim().is_empty()).then_some(value))
+}
+
+fn store_secure_value(key: &str, value: &str) -> Result<(), String> {
+    let encrypted = encrypt_secret(value.trim())?;
+    let conn = open_history_db()?;
+    conn.execute(
+        "INSERT OR REPLACE INTO secure_settings (key, value, updated_at) VALUES (?1, ?2, ?3)",
+        params![key, encrypted, format_time(Local::now())],
     )
     .map_err(|e| e.to_string())?;
     Ok(())
@@ -2302,5 +2666,77 @@ mod tests {
         assert!(!keep_log_line("[2026-01-01 23:59:59] old", cutoff));
         assert!(keep_log_line("[2026-01-02 00:00:00] keep", cutoff));
         assert!(keep_log_line("unstructured line", cutoff));
+    }
+
+    #[test]
+    fn parses_opencode_go_dashboard_html() {
+        let ssr = concat!(
+            "<script>",
+            "rollingUsage:$R[40]={usagePercent:42.5,resetInSec:6960}",
+            "weeklyUsage:$R[41]={resetInSec:2307600,usagePercent:80}",
+            "monthlyUsage:$R[42]={usagePercent:15,resetInSec:2307600}",
+            "</script>",
+        );
+        let quota = parse_opencode_go_quota(ssr).expect("SSR quota parses");
+        let rolling = quota.rolling.expect("rolling window");
+        assert_eq!(rolling.usage_percent, 42.5);
+        assert_eq!(rolling.reset_in_sec, 6960);
+        assert!((rolling.percent_remaining - 57.5).abs() < 1e-9);
+        let weekly = quota.weekly.expect("weekly window");
+        assert_eq!(weekly.usage_percent, 80.0);
+        assert_eq!(weekly.reset_in_sec, 2307600);
+        let monthly = quota.monthly.expect("monthly window");
+        assert_eq!(monthly.usage_percent, 15.0);
+
+        let slot = concat!(
+            r#"<div data-slot="usage-item">"#,
+            r#"<span data-slot="usage-label">Rolling Usage</span>"#,
+            r#"<span data-slot="usage-value">42.5%</span>"#,
+            r#"<span data-slot="reset-time">1 hour 56 minutes</span>"#,
+            r#"</div>"#,
+            r#"<div data-slot="usage-item">"#,
+            r#"<span data-slot="usage-label">Weekly Usage</span>"#,
+            r#"<span data-slot="usage-value">80%</span>"#,
+            r#"<span data-slot="reset-time">26 days 17 hours</span>"#,
+            r#"</div>"#,
+            r#"<div data-slot="usage-item">"#,
+            r#"<span data-slot="usage-label">Monthly Usage</span>"#,
+            r#"<span data-slot="usage-value">15%</span>"#,
+            r#"<span data-slot="reset-now">Resets now</span>"#,
+            r#"</div>"#,
+        );
+        let quota = parse_opencode_go_quota(slot).expect("data-slot quota parses");
+        let rolling = quota.rolling.expect("slot rolling");
+        assert_eq!(rolling.usage_percent, 42.5);
+        assert_eq!(rolling.reset_in_sec, 6960);
+        let weekly = quota.weekly.expect("slot weekly");
+        assert_eq!(weekly.usage_percent, 80.0);
+        assert_eq!(weekly.reset_in_sec, 26 * 86400 + 17 * 3600);
+        let monthly = quota.monthly.expect("slot monthly");
+        assert_eq!(monthly.reset_in_sec, 0);
+
+        assert_eq!(parse_human_readable_time("1 hour 56 minutes"), Some(6960));
+        assert_eq!(
+            parse_human_readable_time("26 days 17 hours"),
+            Some(2_307_600)
+        );
+        assert_eq!(parse_human_readable_time("Resets now"), Some(0));
+        assert_eq!(parse_human_readable_time("reset now"), Some(0));
+        assert_eq!(parse_human_readable_time("garbage"), None);
+        assert_eq!(format_reset_seconds(0), "now");
+        assert_eq!(format_reset_seconds(6960), "1h 56m");
+        assert_eq!(format_reset_seconds(2_307_600), "26d 17h");
+        assert_eq!(encode_uri_component("abc-123"), "abc-123");
+        assert_eq!(encode_uri_component("a b"), "a%20b");
+
+        // Unparseable HTML (e.g. login page) yields an error.
+        assert!(parse_opencode_go_quota("<html>sign in</html>").is_err());
+
+        // A partial SSR payload keeps only the windows that are present.
+        let partial = r#"rollingUsage:$R[1]={usagePercent:10,resetInSec:3600}"#;
+        let quota = parse_opencode_go_quota(partial).expect("partial SSR parses");
+        assert!(quota.rolling.is_some());
+        assert!(quota.weekly.is_none());
+        assert!(quota.monthly.is_none());
     }
 }

--- a/rust-windows/Cargo.lock
+++ b/rust-windows/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "deepseek-balance-monitor"
-version = "1.2.6"
+version = "1.2.10"
 dependencies = [
  "chrono",
  "image",

--- a/rust-windows/Cargo.toml
+++ b/rust-windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deepseek-balance-monitor"
-version = "1.2.6"
+version = "1.2.10"
 edition = "2021"
 rust-version = "1.77.2"
 description = "Windows tray balance monitor for the DeepSeek API"

--- a/rust-windows/src/main.rs
+++ b/rust-windows/src/main.rs
@@ -34,6 +34,12 @@ mod windows_app {
     const RAINMETER_ADDR: &str = "127.0.0.1:17654";
     const STARTUP_LINK_NAME: &str = "DeepSeek Balance Monitor.lnk";
     const API_KEY_PLACEHOLDER: &str = "Stored securely. Leave blank to keep the existing API key.";
+    const OPENCODE_GO_URL_PREFIX: &str = "https://opencode.ai/workspace/";
+    const OPENCODE_GO_URL_SUFFIX: &str = "/go";
+    const OPENCODE_GO_USER_AGENT: &str =
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/20100101 Firefox/148.0";
+    const OPENCODE_GO_WORKSPACE_KEY: &str = "opencode_go_workspace_id";
+    const OPENCODE_GO_AUTH_COOKIE_KEY: &str = "opencode_go_auth_cookie";
     const CSIDL_STARTUP: i32 = 0x0007;
     const CSIDL_FLAG_CREATE: i32 = 0x8000;
     const COINIT_APARTMENTTHREADED: u32 = 0x2;
@@ -354,6 +360,20 @@ mod windows_app {
         topped: f64,
         granted: f64,
         service_status: String,
+    }
+
+    #[derive(Clone, Debug)]
+    struct OpenCodeGoUsage {
+        usage_percent: f64,
+        percent_remaining: f64,
+        reset_in_sec: i64,
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct OpenCodeGoQuota {
+        rolling: Option<OpenCodeGoUsage>,
+        weekly: Option<OpenCodeGoUsage>,
+        monthly: Option<OpenCodeGoUsage>,
     }
 
     struct HistorySummary {
@@ -1228,6 +1248,15 @@ mod windows_app {
         _tabs: nwg::TabsContainer,
         _general_tab: nwg::Tab,
         _history_tab: nwg::Tab,
+        _opencode_go_tab: nwg::Tab,
+        _og_workspace_label: nwg::Label,
+        og_workspace_input: nwg::TextInput,
+        _og_cookie_label: nwg::Label,
+        og_cookie_input: nwg::TextInput,
+        og_show_cookie: nwg::CheckBox,
+        _og_hint_box: nwg::TextBox,
+        og_box: nwg::TextBox,
+        refresh_og_button: nwg::Button,
         _api_label: nwg::Label,
         api_input: nwg::TextInput,
         show_key: nwg::CheckBox,
@@ -1279,6 +1308,15 @@ mod windows_app {
             let mut tabs = Default::default();
             let mut general_tab = Default::default();
             let mut history_tab = Default::default();
+            let mut opencode_go_tab = Default::default();
+            let mut og_workspace_label = Default::default();
+            let mut og_workspace_input = Default::default();
+            let mut og_cookie_label = Default::default();
+            let mut og_cookie_input = Default::default();
+            let mut og_show_cookie = Default::default();
+            let mut og_hint_box = Default::default();
+            let mut og_box = Default::default();
+            let mut refresh_og_button = Default::default();
             let mut api_label = Default::default();
             let mut api_input = Default::default();
             let mut show_key = Default::default();
@@ -1336,6 +1374,10 @@ mod windows_app {
                 .text(tr(lang, "history_tab"))
                 .parent(&tabs)
                 .build(&mut history_tab)?;
+            nwg::Tab::builder()
+                .text(tr(lang, "og_tab"))
+                .parent(&tabs)
+                .build(&mut opencode_go_tab)?;
             nwg::Label::builder()
                 .text(tr(lang, "api_key_label"))
                 .position((20, 20))
@@ -1616,6 +1658,85 @@ mod windows_app {
                 .size((455, 330))
                 .parent(&history_tab)
                 .build(&mut history_box)?;
+            let og_workspace_id = read_secure_value(OPENCODE_GO_WORKSPACE_KEY)
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            let og_auth_cookie = read_secure_value(OPENCODE_GO_AUTH_COOKIE_KEY)
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            let og_box_text = if og_workspace_id.is_empty() || og_auth_cookie.is_empty() {
+                tr(lang, "og_not_configured").to_string()
+            } else {
+                String::new()
+            };
+            nwg::Label::builder()
+                .text(tr(lang, "og_workspace_label"))
+                .position((20, 20))
+                .size((200, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_workspace_label)?;
+            nwg::TextInput::builder()
+                .text(&og_workspace_id)
+                .position((20, 48))
+                .size((440, 28))
+                .parent(&opencode_go_tab)
+                .build(&mut og_workspace_input)?;
+            nwg::Label::builder()
+                .text(tr(lang, "og_cookie_label"))
+                .position((20, 90))
+                .size((200, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_cookie_label)?;
+            nwg::TextInput::builder()
+                .text(&og_auth_cookie)
+                .placeholder_text(
+                    (!og_auth_cookie.is_empty()).then_some(tr(lang, "og_cookie_hint")),
+                )
+                .position((20, 118))
+                .size((440, 28))
+                .parent(&opencode_go_tab)
+                .build(&mut og_cookie_input)?;
+            og_cookie_input.set_password_char(Some('*'));
+            nwg::CheckBox::builder()
+                .text(tr(lang, "og_show_cookie"))
+                .position((20, 152))
+                .size((220, 24))
+                .parent(&opencode_go_tab)
+                .check_state(unchecked)
+                .build(&mut og_show_cookie)?;
+            nwg::TextBox::builder()
+                .text(tr(lang, "og_hint"))
+                .flags(
+                    nwg::TextBoxFlags::VISIBLE
+                        | nwg::TextBoxFlags::VSCROLL
+                        | nwg::TextBoxFlags::TAB_STOP,
+                )
+                .readonly(true)
+                .position((20, 186))
+                .size((440, 50))
+                .parent(&opencode_go_tab)
+                .build(&mut og_hint_box)?;
+            nwg::Button::builder()
+                .text(tr(lang, "og_refresh"))
+                .position((20, 248))
+                .size((86, 30))
+                .parent(&opencode_go_tab)
+                .build(&mut refresh_og_button)?;
+            nwg::TextBox::builder()
+                .text(&og_box_text)
+                .flags(
+                    nwg::TextBoxFlags::VISIBLE
+                        | nwg::TextBoxFlags::VSCROLL
+                        | nwg::TextBoxFlags::AUTOVSCROLL
+                        | nwg::TextBoxFlags::TAB_STOP,
+                )
+                .readonly(true)
+                .position((20, 292))
+                .size((440, 230))
+                .parent(&opencode_go_tab)
+                .build(&mut og_box)?;
             nwg::Button::builder()
                 .text(tr(lang, "save"))
                 .position((300, 660))
@@ -1635,6 +1756,15 @@ mod windows_app {
                 _tabs: tabs,
                 _general_tab: general_tab,
                 _history_tab: history_tab,
+                _opencode_go_tab: opencode_go_tab,
+                _og_workspace_label: og_workspace_label,
+                og_workspace_input,
+                _og_cookie_label: og_cookie_label,
+                og_cookie_input,
+                og_show_cookie,
+                _og_hint_box: og_hint_box,
+                og_box,
+                refresh_og_button,
                 _api_label: api_label,
                 api_input,
                 show_key,
@@ -1699,6 +1829,17 @@ mod windows_app {
                                 settings.api_input.set_password_char(Some('*'));
                             }
                         }
+                        nwg::Event::OnButtonClick if &handle == &settings.og_show_cookie => {
+                            if settings.og_show_cookie.check_state() == nwg::CheckBoxState::Checked
+                            {
+                                settings.og_cookie_input.set_password_char(None);
+                            } else {
+                                settings.og_cookie_input.set_password_char(Some('*'));
+                            }
+                        }
+                        nwg::Event::OnButtonClick if &handle == &settings.refresh_og_button => {
+                            settings.refresh_opencode_go();
+                        }
                         nwg::Event::OnButtonClick
                             if &handle == &settings.refresh_history_button =>
                         {
@@ -1728,6 +1869,30 @@ mod windows_app {
                 });
             settings.handler.borrow_mut().replace(handler);
             Ok(settings)
+        }
+
+        fn refresh_opencode_go(&self) {
+            let lang = self.current_language();
+            let workspace_id = self.og_workspace_input.text().trim().to_string();
+            let auth_cookie = self.og_cookie_input.text().trim().to_string();
+            if workspace_id.is_empty() || auth_cookie.is_empty() {
+                self.og_box.set_text(tr(&lang, "og_not_configured"));
+                return;
+            }
+            let proxy = if self.proxy_enabled.check_state() == nwg::CheckBoxState::Checked {
+                self.proxy_input.text().trim().to_string()
+            } else {
+                String::new()
+            };
+            self.og_box.set_text(tr(&lang, "og_checking"));
+            match fetch_opencode_go_quota(&workspace_id, &auth_cookie, &proxy) {
+                Ok(quota) => self
+                    .og_box
+                    .set_text(&format_opencode_go_quota(&quota, &lang)),
+                Err(error) => self
+                    .og_box
+                    .set_text(&format!("{} {error}", tr(&lang, "og_refresh_failed"))),
+            }
         }
 
         fn refresh_history(&self) {
@@ -1789,6 +1954,14 @@ mod windows_app {
             } else {
                 store_secure_api_key(&api_key)?;
                 config.api_key = api_key;
+            }
+            let og_workspace_id = self.og_workspace_input.text().trim().to_string();
+            if !og_workspace_id.is_empty() {
+                store_secure_value(OPENCODE_GO_WORKSPACE_KEY, &og_workspace_id)?;
+            }
+            let og_auth_cookie = self.og_cookie_input.text().trim().to_string();
+            if !og_auth_cookie.is_empty() {
+                store_secure_value(OPENCODE_GO_AUTH_COOKIE_KEY, &og_auth_cookie)?;
             }
             let interval_minutes = self
                 .interval_input
@@ -1904,6 +2077,278 @@ mod windows_app {
             );
         }
         Ok(balances)
+    }
+
+    fn fetch_opencode_go_quota(
+        workspace_id: &str,
+        auth_cookie: &str,
+        http_proxy: &str,
+    ) -> Result<OpenCodeGoQuota, String> {
+        let client = http_client(Duration::from_secs(10), http_proxy)?;
+        let url = format!(
+            "{}{}{}",
+            OPENCODE_GO_URL_PREFIX,
+            encode_uri_component(workspace_id),
+            OPENCODE_GO_URL_SUFFIX
+        );
+        let response = client
+            .get(&url)
+            .header("Accept", "text/html")
+            .header("User-Agent", OPENCODE_GO_USER_AGENT)
+            .header("Cookie", format!("auth={auth_cookie}"))
+            .send()
+            .map_err(|e| format!("OpenCode Go request failed: {e}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().unwrap_or_default();
+            return Err(format!(
+                "OpenCode Go dashboard error {status}: {}",
+                sanitize_opencode_go_message(&text)
+            ));
+        }
+        let html = response
+            .text()
+            .map_err(|e| format!("OpenCode Go HTML read failed: {e}"))?;
+        parse_opencode_go_quota(&html)
+    }
+
+    fn parse_opencode_go_quota(html: &str) -> Result<OpenCodeGoQuota, String> {
+        let ssr = OpenCodeGoQuota {
+            rolling: parse_ssr_window(html, "rollingUsage"),
+            weekly: parse_ssr_window(html, "weeklyUsage"),
+            monthly: parse_ssr_window(html, "monthlyUsage"),
+        };
+        let any = ssr.rolling.is_some() || ssr.weekly.is_some() || ssr.monthly.is_some();
+        let quota = if any {
+            ssr
+        } else {
+            parse_opencode_go_data_slot(html)
+        };
+        if quota.rolling.is_none() && quota.weekly.is_none() && quota.monthly.is_none() {
+            return Err(
+                "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)"
+                    .to_string(),
+            );
+        }
+        Ok(quota)
+    }
+
+    fn parse_ssr_window(html: &str, window: &str) -> Option<OpenCodeGoUsage> {
+        let marker = format!("{window}:$R[");
+        let start = html.find(&marker)?;
+        let rest = &html[start + marker.len()..];
+        let open = rest.find('{')? + 1;
+        let content_end = rest[open..].find('}')?;
+        let content = &rest[open..open + content_end];
+        let usage_percent = number_after_key(content, "usagePercent")?.max(0.0);
+        let reset_in_sec = number_after_key(content, "resetInSec")?.max(0.0);
+        Some(OpenCodeGoUsage {
+            usage_percent,
+            percent_remaining: (100.0 - usage_percent).max(0.0),
+            reset_in_sec: reset_in_sec as i64,
+        })
+    }
+
+    fn parse_opencode_go_data_slot(html: &str) -> OpenCodeGoQuota {
+        let mut quota = OpenCodeGoQuota::default();
+        for item in html.split("data-slot=\"usage-item\"").skip(1) {
+            let Some(label) = tag_text(item, "data-slot=\"usage-label\"") else {
+                continue;
+            };
+            let Some(usage_text) = tag_text(item, "data-slot=\"usage-value\"") else {
+                continue;
+            };
+            let Some(usage_percent) = first_number(&usage_text) else {
+                continue;
+            };
+            let reset_in_sec = if item.contains("data-slot=\"reset-now\"") {
+                0
+            } else {
+                let Some(reset_text) = tag_text(item, "data-slot=\"reset-time\"") else {
+                    continue;
+                };
+                match parse_human_readable_time(&reset_text) {
+                    Some(secs) => secs,
+                    None => continue,
+                }
+            };
+            let window_key = if label.to_lowercase().contains("rolling") {
+                Some("rolling")
+            } else if label.to_lowercase().contains("weekly") {
+                Some("weekly")
+            } else if label.to_lowercase().contains("monthly") {
+                Some("monthly")
+            } else {
+                None
+            };
+            let Some(window_key) = window_key else {
+                continue;
+            };
+            let usage = OpenCodeGoUsage {
+                usage_percent,
+                percent_remaining: (100.0 - usage_percent).max(0.0),
+                reset_in_sec,
+            };
+            match window_key {
+                "rolling" => quota.rolling = Some(usage),
+                "weekly" => quota.weekly = Some(usage),
+                _ => quota.monthly = Some(usage),
+            }
+        }
+        quota
+    }
+
+    fn tag_text<'a>(text: &'a str, marker: &str) -> Option<&'a str> {
+        let start = text.find(marker)? + marker.len();
+        let rest = &text[start..];
+        let open = rest.find('>')? + 1;
+        let content = &rest[open..];
+        let end = content.find('<')?;
+        Some(content[..end].trim())
+    }
+
+    fn number_after_key(text: &str, key: &str) -> Option<f64> {
+        let rest = &text[text.find(key)? + key.len()..];
+        let rest = rest.strip_prefix(':')?;
+        let number: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.' || *c == '-' || *c == '+')
+            .collect();
+        if number.is_empty() {
+            return None;
+        }
+        number.parse().ok()
+    }
+
+    fn first_number(text: &str) -> Option<f64> {
+        let start = text.find(|c: char| c.is_ascii_digit())?;
+        let rest = &text[start..];
+        let number: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.')
+            .collect();
+        if number.is_empty() {
+            return None;
+        }
+        number.parse().ok()
+    }
+
+    fn parse_human_readable_time(text: &str) -> Option<i64> {
+        let normalized = text.to_lowercase();
+        if normalized.contains("reset now")
+            || normalized.contains("resets now")
+            || normalized.trim() == "now"
+        {
+            return Some(0);
+        }
+        let mut total: i64 = 0;
+        let mut found = false;
+        for (plural, singular, multiplier) in [
+            ("days", "day", 86400i64),
+            ("hours", "hour", 3600),
+            ("minutes", "minute", 60),
+            ("seconds", "second", 1),
+        ] {
+            let unit = if normalized.contains(plural) {
+                plural
+            } else {
+                singular
+            };
+            if let Some(prefix) = number_before_word(&normalized, unit) {
+                if let Ok(n) = prefix.parse::<f64>() {
+                    total += (n * multiplier as f64) as i64;
+                    found = true;
+                }
+            }
+        }
+        found.then_some(total)
+    }
+
+    fn number_before_word<'a>(text: &'a str, word: &str) -> Option<&'a str> {
+        let index = text.find(word)?;
+        let before = text[..index].trim_end();
+        if before.is_empty() {
+            return None;
+        }
+        let start = before
+            .rfind(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let candidate = &before[start..];
+        if candidate.is_empty() || !candidate.starts_with(|c: char| c.is_ascii_digit()) {
+            return None;
+        }
+        Some(candidate)
+    }
+
+    fn format_reset_seconds(secs: i64) -> String {
+        if secs <= 0 {
+            return "now".to_string();
+        }
+        let days = secs / 86400;
+        let hours = (secs % 86400) / 3600;
+        let minutes = (secs % 3600) / 60;
+        let mut parts = Vec::new();
+        if days > 0 {
+            parts.push(format!("{days}d"));
+        }
+        if hours > 0 {
+            parts.push(format!("{hours}h"));
+        }
+        if minutes > 0 {
+            parts.push(format!("{minutes}m"));
+        }
+        if parts.is_empty() {
+            parts.push(format!("{}s", secs % 60));
+        }
+        parts.join(" ")
+    }
+
+    fn format_opencode_go_quota(quota: &OpenCodeGoQuota, lang: &str) -> String {
+        let mut lines = vec![tr(lang, "og_title").to_string()];
+        for (label_key, usage) in [
+            ("og_window_5h", quota.rolling.as_ref()),
+            ("og_window_weekly", quota.weekly.as_ref()),
+            ("og_window_monthly", quota.monthly.as_ref()),
+        ] {
+            match usage {
+                Some(usage) => lines.push(format!(
+                    "{}: {:.0}% used | {:.0}% remaining | resets in {}",
+                    tr(lang, label_key),
+                    usage.usage_percent,
+                    usage.percent_remaining,
+                    format_reset_seconds(usage.reset_in_sec)
+                )),
+                None => lines.push(format!(
+                    "{}: {}",
+                    tr(lang, label_key),
+                    tr(lang, "og_unavailable")
+                )),
+            }
+        }
+        lines.join("\n")
+    }
+
+    fn encode_uri_component(value: &str) -> String {
+        let mut out = String::with_capacity(value.len());
+        for byte in value.bytes() {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+                out.push(byte as char);
+            } else {
+                out.push('%');
+                out.push_str(&format!("{byte:02X}"));
+            }
+        }
+        out
+    }
+
+    fn sanitize_opencode_go_message(text: &str) -> String {
+        let cleaned: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        if cleaned.is_empty() {
+            "unknown".to_string()
+        } else {
+            cleaned.chars().take(120).collect()
+        }
     }
 
     fn fetch_service_status(http_proxy: &str) -> String {
@@ -2516,6 +2961,36 @@ mod windows_app {
             "INSERT OR REPLACE INTO secure_settings (key, value, updated_at) VALUES (?1, ?2, ?3)",
             params![
                 "api_key",
+                encrypted,
+                Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    fn read_secure_value(key: &str) -> Result<Option<String>, String> {
+        let conn = open_history_db()?;
+        let encrypted = match conn.query_row(
+            "SELECT value FROM secure_settings WHERE key = ?1",
+            params![key],
+            |row| row.get::<_, Vec<u8>>(0),
+        ) {
+            Ok(value) => value,
+            Err(SqlError::QueryReturnedNoRows) => return Ok(None),
+            Err(error) => return Err(error.to_string()),
+        };
+        let value = decrypt_secret(&encrypted)?;
+        Ok((!value.trim().is_empty()).then_some(value))
+    }
+
+    fn store_secure_value(key: &str, value: &str) -> Result<(), String> {
+        let encrypted = encrypt_secret(value.trim())?;
+        let conn = open_history_db()?;
+        conn.execute(
+            "INSERT OR REPLACE INTO secure_settings (key, value, updated_at) VALUES (?1, ?2, ?3)",
+            params![
+                key,
                 encrypted,
                 Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
             ],
@@ -3486,6 +3961,22 @@ mod windows_app {
             ("en", "api_degraded_msg") => "API service status has changed: ",
             ("en", "api_recovered_title") => "✅ DeepSeek API Recovered",
             ("en", "api_recovered_msg") => "API service is back to normal.",
+            ("en", "og_tab") => "OpenCode Go",
+            ("en", "og_title") => "OpenCode Go",
+            ("en", "og_workspace_label") => "Workspace ID:",
+            ("en", "og_cookie_label") => "Auth cookie:",
+            ("en", "og_show_cookie") => "Show auth cookie",
+            ("en", "og_hint") => "Get the workspace ID from the opencode.ai workspace URL, and the auth cookie from browser Developer Tools -> Storage -> Cookies for opencode.ai. Credentials are encrypted and stored locally.",
+            ("en", "og_refresh") => "Refresh",
+            ("en", "og_window_5h") => "5h",
+            ("en", "og_window_weekly") => "Weekly",
+            ("en", "og_window_monthly") => "Monthly",
+            ("en", "og_unavailable") => "unavailable",
+            ("en", "og_checking") => "Checking...",
+            ("en", "og_not_configured") => "OpenCode Go credentials are not configured. Enter a workspace ID and auth cookie, then click Save.",
+            ("en", "og_credentials_saved") => "Credentials saved.",
+            ("en", "og_refresh_failed") => "Refresh failed:",
+            ("en", "og_cookie_hint") => "Leave blank to keep the existing credentials.",
             ("en", "warn_title") => "Warning",
             (_, "checking") => "查询中...",
             (_, "error") => "错误",
@@ -3589,6 +4080,22 @@ mod windows_app {
             (_, "api_degraded_msg") => "检测到 API 服务状态异常：",
             (_, "api_recovered_title") => "✅ DeepSeek API 服务恢复",
             (_, "api_recovered_msg") => "API 服务已恢复正常。",
+            (_, "og_tab") => "OpenCode Go",
+            (_, "og_title") => "OpenCode Go",
+            (_, "og_workspace_label") => "工作区 ID：",
+            (_, "og_cookie_label") => "Auth Cookie：",
+            (_, "og_show_cookie") => "显示 Auth Cookie",
+            (_, "og_hint") => "工作区 ID 可在 opencode.ai 工作区 URL 中获取；auth cookie 可在浏览器开发者工具 → Storage → Cookies（opencode.ai）中查看。凭据将加密存储在本机。",
+            (_, "og_refresh") => "刷新",
+            (_, "og_window_5h") => "5h",
+            (_, "og_window_weekly") => "每周",
+            (_, "og_window_monthly") => "每月",
+            (_, "og_unavailable") => "不可用",
+            (_, "og_checking") => "查询中...",
+            (_, "og_not_configured") => "尚未配置 OpenCode Go 凭据。请填写工作区 ID 和 Auth Cookie 后点击保存。",
+            (_, "og_credentials_saved") => "凭据已保存。",
+            (_, "og_refresh_failed") => "刷新失败：",
+            (_, "og_cookie_hint") => "留空则保留现有凭据。",
             (_, "warn_title") => "警告",
             _ => "",
         }
@@ -3768,6 +4275,67 @@ mod windows_app {
             assert!(!keep_log_line("[2026-01-01 23:59:59] old", cutoff));
             assert!(keep_log_line("[2026-01-02 00:00:00] keep", cutoff));
             assert!(keep_log_line("unstructured line", cutoff));
+        }
+
+        #[test]
+        fn parses_opencode_go_dashboard_html() {
+            let ssr = concat!(
+                "<script>",
+                "rollingUsage:$R[40]={usagePercent:42.5,resetInSec:6960}",
+                "weeklyUsage:$R[41]={resetInSec:2307600,usagePercent:80}",
+                "monthlyUsage:$R[42]={usagePercent:15,resetInSec:2307600}",
+                "</script>",
+            );
+            let quota = parse_opencode_go_quota(ssr).expect("SSR quota parses");
+            let rolling = quota.rolling.expect("rolling window");
+            assert_eq!(rolling.usage_percent, 42.5);
+            assert_eq!(rolling.reset_in_sec, 6960);
+            assert!((rolling.percent_remaining - 57.5).abs() < 1e-9);
+            let weekly = quota.weekly.expect("weekly window");
+            assert_eq!(weekly.usage_percent, 80.0);
+            assert_eq!(weekly.reset_in_sec, 2307600);
+
+            let slot = concat!(
+                r#"<div data-slot="usage-item">"#,
+                r#"<span data-slot="usage-label">Rolling Usage</span>"#,
+                r#"<span data-slot="usage-value">42.5%</span>"#,
+                r#"<span data-slot="reset-time">1 hour 56 minutes</span>"#,
+                r#"</div>"#,
+                r#"<div data-slot="usage-item">"#,
+                r#"<span data-slot="usage-label">Monthly Usage</span>"#,
+                r#"<span data-slot="usage-value">15%</span>"#,
+                r#"<span data-slot="reset-now">Resets now</span>"#,
+                r#"</div>"#,
+            );
+            let quota = parse_opencode_go_quota(slot).expect("data-slot quota parses");
+            let rolling = quota.rolling.expect("slot rolling");
+            assert_eq!(rolling.usage_percent, 42.5);
+            assert_eq!(rolling.reset_in_sec, 6960);
+            let monthly = quota.monthly.expect("slot monthly");
+            assert_eq!(monthly.reset_in_sec, 0);
+
+            assert_eq!(parse_human_readable_time("1 hour 56 minutes"), Some(6960));
+            assert_eq!(
+                parse_human_readable_time("26 days 17 hours"),
+                Some(2_307_600)
+            );
+            assert_eq!(parse_human_readable_time("Resets now"), Some(0));
+            assert_eq!(parse_human_readable_time("garbage"), None);
+            assert_eq!(format_reset_seconds(0), "now");
+            assert_eq!(format_reset_seconds(6960), "1h 56m");
+            assert_eq!(encode_uri_component("a b"), "a%20b");
+            let formatted = format_opencode_go_quota(&quota, "en");
+            assert!(formatted.contains("5h:"));
+
+            // Unparseable HTML (e.g. login page) yields an error.
+            assert!(parse_opencode_go_quota("<html>sign in</html>").is_err());
+
+            // A partial SSR payload keeps only the windows that are present.
+            let partial = r#"rollingUsage:$R[1]={usagePercent:10,resetInSec:3600}"#;
+            let quota = parse_opencode_go_quota(partial).expect("partial SSR parses");
+            assert!(quota.rolling.is_some());
+            assert!(quota.weekly.is_none());
+            assert!(quota.monthly.is_none());
         }
     }
 }

--- a/rust-windows/src/main.rs
+++ b/rust-windows/src/main.rs
@@ -1255,6 +1255,15 @@ mod windows_app {
         og_cookie_input: nwg::TextInput,
         og_show_cookie: nwg::CheckBox,
         _og_hint_box: nwg::TextBox,
+        _og_rolling_label: nwg::Label,
+        og_rolling_bar: nwg::ProgressBar,
+        _og_rolling_value: nwg::Label,
+        _og_weekly_label: nwg::Label,
+        og_weekly_bar: nwg::ProgressBar,
+        _og_weekly_value: nwg::Label,
+        _og_monthly_label: nwg::Label,
+        og_monthly_bar: nwg::ProgressBar,
+        _og_monthly_value: nwg::Label,
         og_box: nwg::TextBox,
         refresh_og_button: nwg::Button,
         _api_label: nwg::Label,
@@ -1315,6 +1324,15 @@ mod windows_app {
             let mut og_cookie_input = Default::default();
             let mut og_show_cookie = Default::default();
             let mut og_hint_box = Default::default();
+            let mut og_rolling_label = Default::default();
+            let mut og_rolling_bar = Default::default();
+            let mut og_rolling_value = Default::default();
+            let mut og_weekly_label = Default::default();
+            let mut og_weekly_bar = Default::default();
+            let mut og_weekly_value = Default::default();
+            let mut og_monthly_label = Default::default();
+            let mut og_monthly_bar = Default::default();
+            let mut og_monthly_value = Default::default();
             let mut og_box = Default::default();
             let mut refresh_og_button = Default::default();
             let mut api_label = Default::default();
@@ -1724,6 +1742,63 @@ mod windows_app {
                 .size((86, 30))
                 .parent(&opencode_go_tab)
                 .build(&mut refresh_og_button)?;
+            nwg::Label::builder()
+                .text(tr(lang, "og_window_5h"))
+                .position((20, 292))
+                .size((70, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_rolling_label)?;
+            nwg::ProgressBar::builder()
+                .position((95, 290))
+                .size((270, 14))
+                .range(0..100)
+                .pos(0)
+                .parent(&opencode_go_tab)
+                .build(&mut og_rolling_bar)?;
+            nwg::Label::builder()
+                .text("--")
+                .position((370, 292))
+                .size((90, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_rolling_value)?;
+            nwg::Label::builder()
+                .text(tr(lang, "og_window_weekly"))
+                .position((20, 330))
+                .size((70, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_weekly_label)?;
+            nwg::ProgressBar::builder()
+                .position((95, 328))
+                .size((270, 14))
+                .range(0..100)
+                .pos(0)
+                .parent(&opencode_go_tab)
+                .build(&mut og_weekly_bar)?;
+            nwg::Label::builder()
+                .text("--")
+                .position((370, 330))
+                .size((90, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_weekly_value)?;
+            nwg::Label::builder()
+                .text(tr(lang, "og_window_monthly"))
+                .position((20, 368))
+                .size((70, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_monthly_label)?;
+            nwg::ProgressBar::builder()
+                .position((95, 366))
+                .size((270, 14))
+                .range(0..100)
+                .pos(0)
+                .parent(&opencode_go_tab)
+                .build(&mut og_monthly_bar)?;
+            nwg::Label::builder()
+                .text("--")
+                .position((370, 368))
+                .size((90, 22))
+                .parent(&opencode_go_tab)
+                .build(&mut og_monthly_value)?;
             nwg::TextBox::builder()
                 .text(&og_box_text)
                 .flags(
@@ -1733,8 +1808,8 @@ mod windows_app {
                         | nwg::TextBoxFlags::TAB_STOP,
                 )
                 .readonly(true)
-                .position((20, 292))
-                .size((440, 230))
+                .position((20, 406))
+                .size((440, 80))
                 .parent(&opencode_go_tab)
                 .build(&mut og_box)?;
             nwg::Button::builder()
@@ -1763,6 +1838,15 @@ mod windows_app {
                 og_cookie_input,
                 og_show_cookie,
                 _og_hint_box: og_hint_box,
+                _og_rolling_label: og_rolling_label,
+                og_rolling_bar,
+                _og_rolling_value: og_rolling_value,
+                _og_weekly_label: og_weekly_label,
+                og_weekly_bar,
+                _og_weekly_value: og_weekly_value,
+                _og_monthly_label: og_monthly_label,
+                og_monthly_bar,
+                _og_monthly_value: og_monthly_value,
                 og_box,
                 refresh_og_button,
                 _api_label: api_label,
@@ -1877,6 +1961,7 @@ mod windows_app {
             let auth_cookie = self.og_cookie_input.text().trim().to_string();
             if workspace_id.is_empty() || auth_cookie.is_empty() {
                 self.og_box.set_text(tr(&lang, "og_not_configured"));
+                self.reset_opencode_go_bars();
                 return;
             }
             let proxy = if self.proxy_enabled.check_state() == nwg::CheckBoxState::Checked {
@@ -1885,13 +1970,83 @@ mod windows_app {
                 String::new()
             };
             self.og_box.set_text(tr(&lang, "og_checking"));
+            self.reset_opencode_go_bars();
             match fetch_opencode_go_quota(&workspace_id, &auth_cookie, &proxy) {
-                Ok(quota) => self
-                    .og_box
-                    .set_text(&format_opencode_go_quota(&quota, &lang)),
+                Ok(quota) => {
+                    self.update_opencode_go_bars(&quota, &lang);
+                    self.og_box.set_text(tr(&lang, "og_loaded"));
+                }
                 Err(error) => self
                     .og_box
                     .set_text(&format!("{} {error}", tr(&lang, "og_refresh_failed"))),
+            }
+        }
+
+        fn update_opencode_go_bars(&self, quota: &OpenCodeGoQuota, lang: &str) {
+            self.set_opencode_go_bar(
+                &self.og_rolling_bar,
+                &self._og_rolling_value,
+                quota.rolling.as_ref(),
+                lang,
+            );
+            self.set_opencode_go_bar(
+                &self.og_weekly_bar,
+                &self._og_weekly_value,
+                quota.weekly.as_ref(),
+                lang,
+            );
+            self.set_opencode_go_bar(
+                &self.og_monthly_bar,
+                &self._og_monthly_value,
+                quota.monthly.as_ref(),
+                lang,
+            );
+        }
+
+        fn set_opencode_go_bar(
+            &self,
+            bar: &nwg::ProgressBar,
+            value: &nwg::Label,
+            usage: Option<&OpenCodeGoUsage>,
+            lang: &str,
+        ) {
+            match usage {
+                Some(usage) => {
+                    bar.set_pos(usage.usage_percent.clamp(0.0, 100.0) as u32);
+                    bar.set_state(match usage.usage_percent {
+                        percent if percent >= 80.0 => nwg::ProgressBarState::Error,
+                        percent if percent >= 60.0 => nwg::ProgressBarState::Paused,
+                        _ => nwg::ProgressBarState::Normal,
+                    });
+                    value.set_text(&format!(
+                        "{:.0}% · {}",
+                        usage.usage_percent,
+                        format_reset_seconds(usage.reset_in_sec)
+                    ));
+                }
+                None => {
+                    bar.set_pos(0);
+                    bar.set_state(nwg::ProgressBarState::Normal);
+                    value.set_text(tr(lang, "og_unavailable"));
+                }
+            }
+        }
+
+        fn reset_opencode_go_bars(&self) {
+            for bar in [
+                &self.og_rolling_bar,
+                &self.og_weekly_bar,
+                &self.og_monthly_bar,
+            ] {
+                bar.set_pos(0);
+                bar.set_state(nwg::ProgressBarState::Normal);
+            }
+            for value in [
+                &self._og_rolling_value,
+                &self._og_weekly_value,
+                &self._og_monthly_value,
+            ] {
+                value.set_text("--");
             }
         }
 
@@ -2302,31 +2457,6 @@ mod windows_app {
             parts.push(format!("{}s", secs % 60));
         }
         parts.join(" ")
-    }
-
-    fn format_opencode_go_quota(quota: &OpenCodeGoQuota, lang: &str) -> String {
-        let mut lines = vec![tr(lang, "og_title").to_string()];
-        for (label_key, usage) in [
-            ("og_window_5h", quota.rolling.as_ref()),
-            ("og_window_weekly", quota.weekly.as_ref()),
-            ("og_window_monthly", quota.monthly.as_ref()),
-        ] {
-            match usage {
-                Some(usage) => lines.push(format!(
-                    "{}: {:.0}% used | {:.0}% remaining | resets in {}",
-                    tr(lang, label_key),
-                    usage.usage_percent,
-                    usage.percent_remaining,
-                    format_reset_seconds(usage.reset_in_sec)
-                )),
-                None => lines.push(format!(
-                    "{}: {}",
-                    tr(lang, label_key),
-                    tr(lang, "og_unavailable")
-                )),
-            }
-        }
-        lines.join("\n")
     }
 
     fn encode_uri_component(value: &str) -> String {
@@ -3976,6 +4106,7 @@ mod windows_app {
             ("en", "og_not_configured") => "OpenCode Go credentials are not configured. Enter a workspace ID and auth cookie, then click Save.",
             ("en", "og_credentials_saved") => "Credentials saved.",
             ("en", "og_refresh_failed") => "Refresh failed:",
+            ("en", "og_loaded") => "Loaded.",
             ("en", "og_cookie_hint") => "Leave blank to keep the existing credentials.",
             ("en", "warn_title") => "Warning",
             (_, "checking") => "查询中...",
@@ -4095,6 +4226,7 @@ mod windows_app {
             (_, "og_not_configured") => "尚未配置 OpenCode Go 凭据。请填写工作区 ID 和 Auth Cookie 后点击保存。",
             (_, "og_credentials_saved") => "凭据已保存。",
             (_, "og_refresh_failed") => "刷新失败：",
+            (_, "og_loaded") => "已加载。",
             (_, "og_cookie_hint") => "留空则保留现有凭据。",
             (_, "warn_title") => "警告",
             _ => "",
@@ -4308,8 +4440,6 @@ mod windows_app {
                 r#"</div>"#,
             );
             let quota = parse_opencode_go_quota(slot).expect("data-slot quota parses");
-            let formatted = format_opencode_go_quota(&quota, "en");
-            assert!(formatted.contains("5h:"));
             let rolling = quota.rolling.expect("slot rolling");
             assert_eq!(rolling.usage_percent, 42.5);
             assert_eq!(rolling.reset_in_sec, 6960);

--- a/rust-windows/src/main.rs
+++ b/rust-windows/src/main.rs
@@ -4308,6 +4308,8 @@ mod windows_app {
                 r#"</div>"#,
             );
             let quota = parse_opencode_go_quota(slot).expect("data-slot quota parses");
+            let formatted = format_opencode_go_quota(&quota, "en");
+            assert!(formatted.contains("5h:"));
             let rolling = quota.rolling.expect("slot rolling");
             assert_eq!(rolling.usage_percent, 42.5);
             assert_eq!(rolling.reset_in_sec, 6960);
@@ -4324,8 +4326,6 @@ mod windows_app {
             assert_eq!(format_reset_seconds(0), "now");
             assert_eq!(format_reset_seconds(6960), "1h 56m");
             assert_eq!(encode_uri_component("a b"), "a%20b");
-            let formatted = format_opencode_go_quota(&quota, "en");
-            assert!(formatted.contains("5h:"));
 
             // Unparseable HTML (e.g. login page) yields an error.
             assert!(parse_opencode_go_quota("<html>sign in</html>").is_err());


### PR DESCRIPTION
- OpenCode Go 额度显示：爬取 opencode.ai 工作区仪表板，解析 5h/每周/每月三档用量
  - rust-windows：设置窗口新增独立「Opencode Go」标签页（配置凭据 + 手动刷新）
  - rust-linux CLI：新增 dsmon opencode-go、opencode-go set、opencode-go json 三个子命令
  - Plasma 6：新增独立「OpenCode Go」设置页面
  - 进度条展示：按用量分级变色（绿 <60% / 琥珀 60–79% / 红 ≥80%），两平台外观一致
  - 凭据加密存储：workspace_id 与 auth_cookie 加密存 SQLite secure_settings 表，不落 config.json